### PR TITLE
Allow overflow in Card to avoid autocomplete list from being cut

### DIFF
--- a/lib/js/components/Cards/Card/Card.vue
+++ b/lib/js/components/Cards/Card/Card.vue
@@ -20,7 +20,6 @@
 	background-color: $color-default-background;
 	border-radius: $radius-m;
 	box-shadow: $shadow-s;
-	overflow: hidden;
 
 	&__header {
 		padding: $space-s;

--- a/lib/js/components/Cards/CardExpandable/CardExpandable.vue
+++ b/lib/js/components/Cards/CardExpandable/CardExpandable.vue
@@ -38,7 +38,7 @@
 	&__expander {
 		align-items: center;
 		background-color: $color-neutral-background;
-		border-radius: $radius-m $radius-m 0 0;
+		border-radius: 0 0 $radius-m $radius-m;
 		cursor: pointer;
 		display: flex;
 		justify-content: center;

--- a/lib/js/components/Cards/CardExpandable/CardExpandable.vue
+++ b/lib/js/components/Cards/CardExpandable/CardExpandable.vue
@@ -26,6 +26,7 @@
 <style lang="scss" scoped>
 @import '../../../../styles/settings/colors/tokens';
 @import '../../../../styles/settings/icons';
+@import '../../../../styles/settings/radiuses';
 @import '../../../../styles/settings/spacings';
 @import '../../../../styles/settings/typography';
 
@@ -37,6 +38,7 @@
 	&__expander {
 		align-items: center;
 		background-color: $color-neutral-background;
+		border-radius: $radius-m $radius-m 0 0;
 		cursor: pointer;
 		display: flex;
 		justify-content: center;


### PR DESCRIPTION
Fix for:
![image](https://user-images.githubusercontent.com/7030884/169280744-b8976e94-9eed-44f4-b681-8fbc3283603b.png)

Expander in `CardExpandable` is still rounded: https://wnl-design-system-preview.s3.eu-central-1.amazonaws.com/IT-4499/index.html?path=/story/components-cards-cardexpandable--interactive

Discussion: https://bethinkteam.slack.com/archives/CFBLF5RGA/p1652783553779939