### PR TITLE
Skip umd-min and commonjs to speed up build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": "^14.15.0 || ^16.13.0"
   },
   "scripts": {
-    "build": "vue-cli-service build --target lib --name design-system lib/js/index.ts",
+    "build": "vue-cli-service build --target lib --formats umd --name design-system lib/js/index.ts",
     "dev": "start-storybook -p 6006",
     "lint": "yarn lint:scripts && yarn lint:styles",
     "lint:fix": "yarn lint:scripts:fix && yarn lint:styles:fix",


### PR DESCRIPTION
I believe we're only using the `umd` build: https://github.com/bethinkpl/design-system/blob/32ea93cb43f1026f2aab118f2d98240f6234d4d7/package.json#L7

Here is the docs on how to skip unnecessary formats:
https://cli.vuejs.org/guide/cli-service.html#vue-cli-service-build

Before:
```
  File                             Size                                                                                                                  Gzipped

  dist/design-system.umd.min.js    13664.19 KiB                                                                                                          4325.28 KiB
  dist/design-system.umd.js        16286.30 KiB                                                                                                          4480.44 KiB
  dist/design-system.common.js     16285.90 KiB                                                                                                          4480.33 KiB

  Images and other types of assets omitted.

✨  Done in 103.83s.
```

After:
```
  File                         Size                                                                                                                    Gzipped

  dist/design-system.umd.js    16286.30 KiB                                                                                                            4480.44 KiB

  Images and other types of assets omitted.

✨  Done in 34.36s.

```