### PR TITLE
Remove dead code from SelectListItemToggle.vue

### DIFF
--- a/lib/js/components/SelectList/SelectListItemToggle/SelectListItemToggle.vue
+++ b/lib/js/components/SelectList/SelectListItemToggle/SelectListItemToggle.vue
@@ -73,10 +73,6 @@ export default {
 	},
 	computed: {
 		icon(): IconItem | null {
-			if (this.isLoading) {
-				return ICONS.FAD_SPINNER_THIRD;
-			}
-
 			return this.isOn ? this.iconOn : this.iconOff;
 		},
 		label(): string {


### PR DESCRIPTION
It was causing:
```
[Vue warn]: Property "isLoading" was accessed during render but is not defined on instance. 
  at <SelectListItemToggle ...
```

Icon is overriden anyway in https://github.com/bethinkpl/design-system/blob/dc99493840218ab59eb12cee53417ceb7869a903/lib/js/components/SelectList/SelectListItem/SelectListItem.vue#L16