### PR TITLE
Fix double events by enabling and fixing require-explicit-emits rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -129,6 +129,7 @@ module.exports = {
 		// Required for Vue 3 migration
 		'vue/no-deprecated-slot-attribute': 'error',
 		'vue/no-deprecated-slot-scope-attribute': 'error',
+		'vue/require-explicit-emits': 'error',
 
 		// https://v3-migration.vuejs.org/breaking-changes/key-attribute.html
 		'vue/no-v-for-template-key': ['off'],

--- a/lib/js/components/Banner/Banner.vue
+++ b/lib/js/components/Banner/Banner.vue
@@ -342,6 +342,7 @@ export default {
 			default: false,
 		},
 	},
+	emits: ['button-clicked', 'close', 'update:isExpanded'],
 	data() {
 		return {
 			isExpandedInternal: false,

--- a/lib/js/components/Cards/CardExpandable/CardExpandable.vue
+++ b/lib/js/components/Cards/CardExpandable/CardExpandable.vue
@@ -112,6 +112,7 @@ export default {
 			default: false,
 		},
 	},
+	emits: ['update:isExpanded'],
 	data() {
 		return {
 			isExpandedInternal: false,

--- a/lib/js/components/Dropdown/Dropdown.vue
+++ b/lib/js/components/Dropdown/Dropdown.vue
@@ -114,6 +114,7 @@ export default {
 			},
 		},
 	},
+	emits: ['document-click', 'hide', 'show'],
 	data() {
 		return {
 			key: 1,

--- a/lib/js/components/Headers/OverlayHeader/OverlayHeader.vue
+++ b/lib/js/components/Headers/OverlayHeader/OverlayHeader.vue
@@ -295,6 +295,7 @@ export default {
 			default: false,
 		},
 	},
+	emits: ['close', 'titleClick'],
 	data() {
 		return {
 			ICON_BUTTON_SIZES: Object.freeze(ICON_BUTTON_SIZES),

--- a/lib/js/components/Layouts/ThreeColumnLayout/ThreeColumnLayout.vue
+++ b/lib/js/components/Layouts/ThreeColumnLayout/ThreeColumnLayout.vue
@@ -235,6 +235,7 @@ export default {
 			default: false,
 		},
 	},
+	emits: ['overlay-clicked'],
 	data() {
 		return {
 			THREE_COLUMN_LAYOUT_RIGHT_COLUMN_SIZE: Object.freeze(

--- a/lib/js/components/Modal/Modal.vue
+++ b/lib/js/components/Modal/Modal.vue
@@ -117,6 +117,7 @@ export default {
 			default: false,
 		},
 	},
+	emits: ['close-modal'],
 	data() {
 		return {
 			ICONS: Object.freeze(ICONS),

--- a/lib/js/components/Modals/Modal/Modal.vue
+++ b/lib/js/components/Modals/Modal/Modal.vue
@@ -404,6 +404,13 @@ export default {
 			default: null,
 		},
 	},
+	emits: [
+		'tertiary-button-click',
+		'checkbox-change',
+		'close-modal',
+		'secondary-button-click',
+		'primary-button-click',
+	],
 	data() {
 		return {
 			BUTTON_COLORS: Object.freeze(BUTTON_COLORS),

--- a/lib/js/components/Modals/ModalDialog/ModalDialog.vue
+++ b/lib/js/components/Modals/ModalDialog/ModalDialog.vue
@@ -86,6 +86,7 @@ export default {
 			},
 		},
 	},
+	emits: ['close-modal', 'primary-button-click', 'secondary-button-click'],
 	data() {
 		return {
 			MODAL_SIZES: Object.freeze(MODAL_SIZES),

--- a/lib/js/components/Pagination/Pagination.vue
+++ b/lib/js/components/Pagination/Pagination.vue
@@ -275,6 +275,7 @@ export default {
 			required: true,
 		},
 	},
+	emits: ['change-page'],
 	data() {
 		return {
 			ICON_BUTTON_SIZES: Object.freeze(ICON_BUTTON_SIZES),

--- a/lib/js/components/Pill/Pill.vue
+++ b/lib/js/components/Pill/Pill.vue
@@ -254,6 +254,7 @@ export default {
 			default: false,
 		},
 	},
+	emits: ['delete'],
 	data() {
 		return {
 			ICONS: Object.freeze(ICONS),

--- a/lib/js/components/PopOver/PopOver.vue
+++ b/lib/js/components/PopOver/PopOver.vue
@@ -273,6 +273,7 @@ export default {
 			default: '',
 		},
 	},
+	emits: ['button-click'],
 	data() {
 		return {
 			POP_OVER_COLORS: Object.freeze(POP_OVER_COLORS),

--- a/lib/js/components/SurveyQuestions/SurveyQuestionScale/SurveyQuestionScale.vue
+++ b/lib/js/components/SurveyQuestions/SurveyQuestionScale/SurveyQuestionScale.vue
@@ -220,6 +220,7 @@ export default {
 			default: null,
 		},
 	},
+	emits: ['elaboration-change', 'select-change'],
 	data() {
 		return {
 			showModal: false,

--- a/lib/js/components/TabItem/TabItem.vue
+++ b/lib/js/components/TabItem/TabItem.vue
@@ -128,6 +128,7 @@ export default {
 			default: TAB_ITEM_SIZES.MEDIUM,
 		},
 	},
+	emits: ['click'],
 	data() {
 		return {
 			TAB_ITEM_SIZES: Object.freeze(TAB_ITEM_SIZES),


### PR DESCRIPTION
I only confirmed that events in ModalDialog were duplicated, but I suspect other components could be affected too. Safer to just enable https://eslint.vuejs.org/rules/require-explicit-emits.html which is strongly recommended anyway.