### PR TITLE
Make title optional in DrawerHeader

### DIFF
--- a/lib/js/components/Drawer/DrawerHeader/DrawerHeader.vue
+++ b/lib/js/components/Drawer/DrawerHeader/DrawerHeader.vue
@@ -161,7 +161,7 @@ export default {
 	props: {
 		title: {
 			type: String,
-			required: true,
+			default: null,
 		},
 		eyebrowText: {
 			type: String,


### PR DESCRIPTION
https://bethinkteam.slack.com/archives/C012R8RM3A4/p1706089647128529?thread_ts=1706081103.541269&cid=C012R8RM3A4

`title` isn't visible when `is-second-level` is set to true, so it doesn't make sense as a required prop. We're already getting warnings about https://github.com/bethinkpl/wnl-platform/blob/0be7b94eabdc50996f320562bbcf9d29be3de3e8/resources/assets/js/modules/multistepProblems/components/MultistepProblemSelectedReferenceDrawer.vue#L4-L10