### PR TITLE
Revert "Update build-dist-on-trigger.yml to post message in PR with install details"

### DIFF
--- a/.github/workflows/build-dist-on-trigger.yml
+++ b/.github/workflows/build-dist-on-trigger.yml
@@ -56,18 +56,3 @@ jobs:
           commit_message: Build dist
           create_branch: true
           push_options: '--force'
-
-      - name: Get last commit hash from branch and set to variable
-        id: last-commit
-        run: |
-          git fetch origin ${{ steps.comment-pr-ref.outputs.result }}-dist
-          echo "::set-output name=commit_hash::$(git log -n 1 origin/${{ steps.comment-pr-ref.outputs.result }}-dist --pretty=format:"%H")"
-
-      - name: Add comment to PR with dist package name and install command
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          pr_number: ${{ github.event.issue.number }}
-          message: |
-            Branch: `${{ steps.comment-pr-ref.outputs.result }}-dist`
-            Last commit: `${{ steps.last-commit.outputs.commit_hash }}`
-            Install: `yarn add '@bethinkpl/design-system@https://github.com/bethinkpl/design-system#commit=${{ steps.last-commit.outputs.commit_hash }}'`


### PR DESCRIPTION
Reverts bethinkpl/design-system#375

It doesn't work:
![Screenshot 2024-07-04 at 08 44 24](https://github.com/bethinkpl/design-system/assets/7030884/8434368c-30c9-455c-80bf-51e957160b68)
