### PR TITLE
Run npm pkg fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "@bethinkpl/design-system",
   "version": "22.2.0",
   "description": "Bethink universe design-system",
-  "repository": "git@github.com:bethinkpl/design-system.git",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/bethinkpl/design-system.git"
+  },
   "author": "nerdy@bethink.pl",
   "main": "./dist/design-system.umd.js",
   "typings": "./dist/lib/js/index.d.ts",
@@ -82,7 +85,7 @@
     "typescript": "4.6.4",
     "vue": "3.2.45",
     "vue-loader": "17.0.0",
-    "vue-popperjs": "bethinkpl/vue-popper#03c7912c4729386743b0cca8f39b35448cc3db7f",
+    "vue-popperjs": "github:bethinkpl/vue-popper#03c7912c4729386743b0cca8f39b35448cc3db7f",
     "vue-svg-loader": "0.17.0-beta.2"
   }
 }


### PR DESCRIPTION
```
design-system git:(master) npm publish --access public
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "repository" was changed from a string to an object
npm warn publish "repository.url" was normalized to "git+ssh://git@github.com/bethinkpl/design-system.git"
npm warn publish Normalized git reference to "devDependencies.vue-popperjs"
```