### PR TITLE
Stop propagation on chip remove click

### DIFF
--- a/lib/js/components/Chip/Chip.vue
+++ b/lib/js/components/Chip/Chip.vue
@@ -33,7 +33,7 @@
 			:size="ICON_BUTTON_SIZES.XX_SMALL"
 			:icon="ICONS.FA_XMARK"
 			:elevation="BUTTON_ELEVATIONS.X_SMALL"
-			@click="$emit('remove')"
+			@click.stop="$emit('remove')"
 		/>
 	</div>
 </template>


### PR DESCRIPTION
In case of need to use `@click` on DsChip, `@remove` event should stop propagation