### PR TITLE
Make label prop in OutlineItem optional to avoid false-positive warnings

### DIFF
--- a/lib/js/components/Outline/OutlineItem/OutlineItem.vue
+++ b/lib/js/components/Outline/OutlineItem/OutlineItem.vue
@@ -270,7 +270,8 @@ export default defineComponent({
 		},
 		label: {
 			type: String,
-			required: true,
+			// Label can be passed either as a prop or in a slot
+			default: '',
 		},
 		isLabelUppercase: {
 			type: Boolean,


### PR DESCRIPTION
Fix for:
```
[Vue warn]: Missing required prop: "label" 
  at <OutlineItem key="step-15191" class="multistepProblemPartOutline__walkthroughItem" state="default"  ... > 
  at <Drawer class="multistepProblemPartOutline multistepProblemPartOverlayView__outline" position="left" > 
  at <MultistepProblemPartOutline class="multistepProblemPartOverlayView__outline" is-answer-and-markscheme-disabled=false is-part-preview=false  ... > 
```

We're passing label in a slot there, as allowed by the `OutlineItem`, it shouldn't cause a warning:
https://github.com/bethinkpl/design-system/blob/1e5de02560a2cf1f416b0ffd0c8fd293601dc14d/lib/js/components/Outline/OutlineItem/OutlineItem.vue#L31-L36

I'd like to validate that either prop or slot were passed but prop validator doesn't have access to the slots.