### PR TITLE
IT-6250 | Add flex-shrink to main avatar element

### DIFF
--- a/lib/js/components/Avatar/Avatar.vue
+++ b/lib/js/components/Avatar/Avatar.vue
@@ -47,6 +47,8 @@
 	$root: &;
 
 	display: flex;
+	// Explicit width&height doesn't prevent element from shrinking. Therefore, this needs to be set.
+	flex-shrink: 0;
 	position: relative;
 
 	&.-ds-xx-small {


### PR DESCRIPTION
We don't want this element to shrink, therefore, let's explicitly set the flex-shrink to 0 so the element is not affected by other around it.