### PR TITLE
IT-6456 | Do not override focused border color on hover

### DIFF
--- a/lib/js/components/Form/InputField/InputField.vue
+++ b/lib/js/components/Form/InputField/InputField.vue
@@ -76,7 +76,7 @@
 		border-color: $color-danger-border;
 	}
 
-	&:hover:not(.-ds-disabled) {
+	&:hover:not(.-ds-disabled):not(:focus-within) {
 		border-color: $color-neutral-border-strong-hovered;
 	}
 


### PR DESCRIPTION
It didn't work well on touch screen when hover state persists after tap