### PR TITLE
IT-7543 Reduce button min-width from 100px to 50px

### DIFF
--- a/lib/styles/components/_buttons.scss
+++ b/lib/styles/components/_buttons.scss
@@ -240,7 +240,7 @@ $button-disabled-alpha: 0.6;
 	}
 
 	&:not(.-ds-text) {
-		min-width: 100px;
+		min-width: 50px;
 
 		&.-ds-rounded {
 			border-radius: $radius-s;


### PR DESCRIPTION
## Summary
Reduces the minimum width of non-text buttons from `100px` to `50px`.

## Changes
- `lib/styles/components/_buttons.scss`: `min-width` for `&:not(.-ds-text)` changed `100px` → `50px`

🤖 Generated with [Claude Code](https://claude.com/claude-code)