### PR TITLE
Add versioned NPM publish workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,55 @@
+name: Publish to NPM
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Version bump type'
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+concurrency:
+  group: publish-npm
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+    # if: github.ref == 'refs/heads/master'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20.9.0'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Bump version
+        id: bump
+        run: |
+          NEW_VERSION=$(npm version ${{ inputs.release_type }} -m "Bump version to \`v%s\`")
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+      - name: Push commit and tag
+        run: git push origin HEAD:master --follow-tags
+      - name: Create GitHub release
+        run: gh release create "${{ steps.bump.outputs.version }}" --generate-notes --title "${{ steps.bump.outputs.version }}" --draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish
+        # NODE_AUTH_TOKEN is read by the .npmrc written by setup-node (registry-url triggers this).
+        # See: https://github.com/actions/setup-node/blob/0355742c943ddb13ca8a6b700f824231caa91e75/docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-npm
+        run: npm publish --access public --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -21,7 +21,6 @@ jobs:
   publish:
     name: Publish to NPM
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
     permissions:
       contents: write
     steps:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -21,7 +21,7 @@ jobs:
   publish:
     name: Publish to NPM
     runs-on: ubuntu-latest
-    # if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     permissions:
       contents: write
     steps:
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: '20.9.0'
+          node-version-file: 'package.json'
           registry-url: 'https://registry.npmjs.org'
       - name: Configure git identity
         run: |

--- a/README.md
+++ b/README.md
@@ -28,4 +28,6 @@ If you use the review command more than once and the changes are not visible in 
 1. Bump version in `package.json`
 2. Wait until `Build and Deploy Dist` Github Action finishes
 3. Create new tag and release in https://github.com/bethinkpl/design-system/releases
-4. Run `npm publish --access public`
+4. Publish to NPM by triggering the **Publish to NPM** action manually: Actions → Publish to NPM → Run workflow
+
+> **Note:** `NPM_TOKEN` must be set in repository secrets. The recommended token type is a [Granular Access Token](https://docs.npmjs.com/creating-and-viewing-access-tokens#creating-granular-access-tokens-on-the-website) scoped to this package only. Avoid running `npm publish` locally.

--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ If you use the review command more than once and the changes are not visible in 
 `?cd=123`
 
 ## Releasing
-1. Bump version in `package.json`
-2. Wait until `Build and Deploy Dist` Github Action finishes
-3. Create new tag and release in https://github.com/bethinkpl/design-system/releases
-4. Publish to NPM by triggering the **Publish to NPM** action manually: Actions → Publish to NPM → Run workflow
+1. Wait until `Build and Deploy Dist` Github Action finishes
+2. Publish to NPM by triggering the **Publish to NPM** action manually: Actions → Publish to NPM → Run workflow
 
 > **Note:** `NPM_TOKEN` must be set in repository secrets. The recommended token type is a [Granular Access Token](https://docs.npmjs.com/creating-and-viewing-access-tokens#creating-granular-access-tokens-on-the-website) scoped to this package only. Avoid running `npm publish` locally.


### PR DESCRIPTION
## Summary

Adds a manual `workflow_dispatch` workflow for publishing to NPM with an automated version bump.

When triggered, the workflow presents a dropdown to select the release type (patch / minor / patch). It then:

1. Bumps `package.json` via `npm version` and commits + tags directly on master
2. Creates a GitHub release with auto-generated notes
3. Publishes to NPM

**Note:** GitHub release is currently created as `--draft` and publish runs as `--dry-run` for initial testing — both need to be removed before using for a real release.