### PR TITLE
Migrate review deploy from s3cmd to aws s3 sync

### DIFF
--- a/.github/workflows/build-to-review-on-trigger.yml
+++ b/.github/workflows/build-to-review-on-trigger.yml
@@ -64,33 +64,22 @@ jobs:
           yarn install --immutable --immutable-cache
           yarn storybook:build
 
-      - name: Set up S3cmd cli tool
-        uses: s3-actions/s3cmd@v1.4.0
-        with:
-          provider: aws
-          region: 'eu-central-1'
-          access_key: ${{ secrets.S3_ACCESS_KEY }}
-          secret_key: ${{ secrets.S3_SECRET_KEY }}
-
       - name: Push to S3 🚀
-        run: s3cmd put -r -P docs/* s3://${{ vars.S3_REVIEW_BUCKET }}/${{ env.BRANCH_NAME }}/
-
-      - name: "Setting Content-Type to application/javascript for all .js files"
-        run: >-
-          find docs -type f -name "*.js" | while read FILE; do
-            RELATIVE_PATH="${FILE#docs/}"
-            echo "s3://${{ vars.S3_REVIEW_BUCKET }}/${{ env.BRANCH_NAME }}/$RELATIVE_PATH"
-            s3cmd modify --add-header="Content-Type: application/javascript" s3://${{ vars.S3_REVIEW_BUCKET }}/${{ env.BRANCH_NAME }}/$RELATIVE_PATH
-          done
-
-
-      - name: "Set Content-Type to text/css for all .css files"
-        run: >-
-          find docs -type f -name "*.css" | while read FILE; do
-            RELATIVE_PATH="${FILE#docs/}"
-            echo "s3://${{ vars.S3_REVIEW_BUCKET }}/${{ env.BRANCH_NAME }}/$RELATIVE_PATH"
-            s3cmd modify --add-header="Content-Type: text/css" s3://${{ vars.S3_REVIEW_BUCKET }}/${{ env.BRANCH_NAME }}/$RELATIVE_PATH
-          done
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY }}
+          AWS_DEFAULT_REGION: eu-central-1
+        run: |
+          DEST="s3://${{ vars.S3_REVIEW_BUCKET }}/${{ env.BRANCH_NAME }}/"
+          # Everything except js/css — sync infers correct content-types
+          aws s3 sync docs/ "$DEST" --no-progress --acl public-read \
+            --exclude "*.js" --exclude "*.css"
+          # .js files with explicit Content-Type
+          aws s3 sync docs/ "$DEST" --no-progress --acl public-read \
+            --exclude "*" --include "*.js" --content-type "application/javascript"
+          # .css files with explicit Content-Type
+          aws s3 sync docs/ "$DEST" --no-progress --acl public-read \
+            --exclude "*" --include "*.css" --content-type "text/css"
 
       - name: Add comment with URL
         uses: thollander/actions-comment-pull-request@v2


### PR DESCRIPTION
## Summary

Replaces the `s3cmd`-based Storybook review deploy with `aws s3 sync`.

- Uploads `docs/` to the review bucket in three passes: everything except `.js`/`.css` (content-type inferred), then `.js` with `application/javascript`, then `.css` with `text/css`. This folds the old separate `s3cmd modify --add-header` content-type passes into the upload itself.
- **Scopes AWS credentials to the upload step** via inline `env:` instead of writing them into `$GITHUB_ENV`. Previously the secret persisted into the environment of every subsequent step — including the third-party `thollander/actions-comment-pull-request` action; now it is only available to the `Push to S3` step.

## Notes

- `aws` CLI v2 is preinstalled on `ubuntu-latest`.
- Object-key mapping, public-read ACL, recursion, and nested-file content-type handling all preserve the previous behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)