### PR TITLE
IT-7565 Add primary color and isTitleWeak prop to Banner

### DIFF
--- a/lib/js/components/Banner/Banner.consts.ts
+++ b/lib/js/components/Banner/Banner.consts.ts
@@ -3,6 +3,7 @@ import { Value } from '../../utils/type.utils';
 export const BANNER_COLORS = {
 	DEFAULT: 'default',
 	NEUTRAL: 'neutral',
+	PRIMARY: 'primary',
 	INFO: 'info',
 	SUCCESS: 'success',
 	WARNING: 'warning',

--- a/lib/js/components/Banner/Banner.spec.ts
+++ b/lib/js/components/Banner/Banner.spec.ts
@@ -58,6 +58,10 @@ describe('Banner', () => {
 			expectedClass: '-ds-neutral',
 		},
 		{
+			color: BANNER_COLORS.PRIMARY,
+			expectedClass: '-ds-primary',
+		},
+		{
 			color: BANNER_COLORS.INFO,
 			expectedClass: '-ds-info',
 		},
@@ -86,6 +90,17 @@ describe('Banner', () => {
 		});
 
 		expect(wrapper.find('.ds-banner__inner').classes()).toContain(expectedClass);
+	});
+
+	it('renders title with weak weight when titleWeak is set', () => {
+		const wrapper = mount(Banner, {
+			props: {
+				title: 'Test Banner',
+				titleWeak: true,
+			},
+		});
+
+		expect(wrapper.find('.ds-banner__title').classes()).toContain('-ds-titleWeak');
 	});
 
 	it('handles closable', async () => {

--- a/lib/js/components/Banner/Banner.spec.ts
+++ b/lib/js/components/Banner/Banner.spec.ts
@@ -92,11 +92,11 @@ describe('Banner', () => {
 		expect(wrapper.find('.ds-banner__inner').classes()).toContain(expectedClass);
 	});
 
-	it('renders title with weak weight when titleWeak is set', () => {
+	it('renders title with weak weight when isTitleWeak is set', () => {
 		const wrapper = mount(Banner, {
 			props: {
 				title: 'Test Banner',
-				titleWeak: true,
+				isTitleWeak: true,
 			},
 		});
 

--- a/lib/js/components/Banner/Banner.stories.ts
+++ b/lib/js/components/Banner/Banner.stories.ts
@@ -40,6 +40,7 @@ const StoryTemplate: StoryFn<typeof Banner> = (args) => {
 						:is-expanded="isExpanded"
 						:is-icon-hidden-on-mobile="isIconHiddenOnMobile"
 						:size="size"
+						:title-weak="titleWeak"
 						@update:isExpanded="onIsExpandedUpdated"
 				>
 				<template v-if="defaultText" #defaultText><span v-html="defaultText" /></template>
@@ -61,6 +62,7 @@ const args = {
 	icon: null,
 	isIconHiddenOnMobile: false,
 	title: 'Banner Title',
+	titleWeak: false,
 	buttonText: '',
 	closable: false,
 	isExpanded: false,
@@ -85,6 +87,9 @@ const argTypes = {
 	},
 	title: {
 		control: 'text',
+	},
+	titleWeak: {
+		control: 'boolean',
 	},
 	buttonText: {
 		control: 'text',

--- a/lib/js/components/Banner/Banner.stories.ts
+++ b/lib/js/components/Banner/Banner.stories.ts
@@ -40,7 +40,7 @@ const StoryTemplate: StoryFn<typeof Banner> = (args) => {
 						:is-expanded="isExpanded"
 						:is-icon-hidden-on-mobile="isIconHiddenOnMobile"
 						:size="size"
-						:title-weak="titleWeak"
+						:is-title-weak="isTitleWeak"
 						@update:isExpanded="onIsExpandedUpdated"
 				>
 				<template v-if="defaultText" #defaultText><span v-html="defaultText" /></template>
@@ -62,7 +62,7 @@ const args = {
 	icon: null,
 	isIconHiddenOnMobile: false,
 	title: 'Banner Title',
-	titleWeak: false,
+	isTitleWeak: false,
 	buttonText: '',
 	closable: false,
 	isExpanded: false,
@@ -88,7 +88,7 @@ const argTypes = {
 	title: {
 		control: 'text',
 	},
-	titleWeak: {
+	isTitleWeak: {
 		control: 'boolean',
 	},
 	buttonText: {

--- a/lib/js/components/Banner/Banner.vue
+++ b/lib/js/components/Banner/Banner.vue
@@ -22,7 +22,7 @@
 
 					<div class="ds-banner__textWrapper">
 						<div class="ds-banner__titleWrapper">
-							<div class="ds-banner__title">
+							<div class="ds-banner__title" :class="{ '-ds-titleWeak': titleWeak }">
 								<div
 									v-if="icon && size === BANNER_SIZES.SMALL"
 									class="ds-banner__iconWrapperSmall"
@@ -201,6 +201,13 @@
 			border-color: $color-accent-border-weak;
 		}
 
+		&.-ds-primary {
+			--ds-banner-title-color: #{$color-primary-text-strong};
+
+			background-color: $color-primary-background;
+			border-color: $color-primary-border-weak;
+		}
+
 		&.-ds-small {
 			#{$self}__header {
 				padding: 0;
@@ -250,6 +257,10 @@
 		color: var(--ds-banner-title-color);
 		display: flex;
 		gap: $space-3;
+
+		&.-ds-titleWeak {
+			@include heading-s-default-regular;
+		}
 	}
 
 	&__iconWrapperSmall {
@@ -338,6 +349,7 @@ const {
 	color = BANNER_COLORS.DEFAULT,
 	isIconHiddenOnMobile = false,
 	size = BANNER_SIZES.MEDIUM,
+	titleWeak = false,
 } = defineProps<{
 	icon?: IconItem | null;
 	buttonText?: string;
@@ -346,6 +358,7 @@ const {
 	title: string;
 	isIconHiddenOnMobile?: boolean;
 	size?: BannerSize;
+	titleWeak?: boolean;
 }>();
 
 defineEmits<{
@@ -360,6 +373,7 @@ const iconColor = computed(() => {
 	const colorMap: Record<BannerColor, FeatureIconColor> = {
 		[BANNER_COLORS.DEFAULT]: FEATURE_ICON_COLOR.NEUTRAL,
 		[BANNER_COLORS.NEUTRAL]: FEATURE_ICON_COLOR.NEUTRAL,
+		[BANNER_COLORS.PRIMARY]: FEATURE_ICON_COLOR.PRIMARY,
 		[BANNER_COLORS.INFO]: FEATURE_ICON_COLOR.INFO,
 		[BANNER_COLORS.SUCCESS]: FEATURE_ICON_COLOR.SUCCESS,
 		[BANNER_COLORS.WARNING]: FEATURE_ICON_COLOR.WARNING,
@@ -376,6 +390,7 @@ function useBannerClasses() {
 		const colorMap: Record<BannerColor, string> = {
 			[BANNER_COLORS.NEUTRAL]: '-ds-neutral',
 			[BANNER_COLORS.DEFAULT]: '-ds-default',
+			[BANNER_COLORS.PRIMARY]: '-ds-primary',
 			[BANNER_COLORS.FAIL]: '-ds-fail',
 			[BANNER_COLORS.INFO]: '-ds-info',
 			[BANNER_COLORS.SUCCESS]: '-ds-success',

--- a/lib/js/components/Banner/Banner.vue
+++ b/lib/js/components/Banner/Banner.vue
@@ -22,7 +22,7 @@
 
 					<div class="ds-banner__textWrapper">
 						<div class="ds-banner__titleWrapper">
-							<div class="ds-banner__title" :class="{ '-ds-titleWeak': titleWeak }">
+							<div class="ds-banner__title" :class="{ '-ds-titleWeak': isTitleWeak }">
 								<div
 									v-if="icon && size === BANNER_SIZES.SMALL"
 									class="ds-banner__iconWrapperSmall"
@@ -349,7 +349,7 @@ const {
 	color = BANNER_COLORS.DEFAULT,
 	isIconHiddenOnMobile = false,
 	size = BANNER_SIZES.MEDIUM,
-	titleWeak = false,
+	isTitleWeak = false,
 } = defineProps<{
 	icon?: IconItem | null;
 	buttonText?: string;
@@ -358,7 +358,7 @@ const {
 	title: string;
 	isIconHiddenOnMobile?: boolean;
 	size?: BannerSize;
-	titleWeak?: boolean;
+	isTitleWeak?: boolean;
 }>();
 
 defineEmits<{


### PR DESCRIPTION
[IT-7565](https://bethink.atlassian.net/browse/IT-7565)
https://bethinkteam.slack.com/archives/CFBLF5RGA/p1781706153218189

## What

Adds two features to the `Banner` component, per Figma:

- **New `primary` color** — a new color variant alongside the existing ones (info, accent, etc.), using the `primary` design tokens for background, border, title text, and feature-icon color.
- **New `isTitleWeak` prop** — a boolean (default `false`) that renders the title with the regular weight typography token (`heading-s-default-regular`) instead of bold.

## Changes

- `Banner.consts.ts`: added `PRIMARY` to `BANNER_COLORS`.
- `Banner.vue`: `-ds-primary` color block, `isTitleWeak` prop + `-ds-titleWeak` title modifier, and `PRIMARY` entries in the icon-color and color-class maps.
- `Banner.stories.ts`: added `isTitleWeak` control/arg and template binding (`primary` appears automatically in the color dropdown).
- `Banner.spec.ts`: added `primary` to the color test table and a test for `isTitleWeak`.

## Figma

- [primary color](https://www.figma.com/design/izQdYyiBR1GQgFkaOIfIJI/LMS---DS-Components?node-id=17007-6936&m=dev)
- [isTitleWeak](https://www.figma.com/design/izQdYyiBR1GQgFkaOIfIJI/LMS---DS-Components?node-id=17022-15806&m=dev)

## Testing

- `npx vitest run lib/js/components/Banner/Banner.spec.ts` — 16/16 pass.
- Verify in Storybook (Components/Banner): select `color = primary`, toggle `isTitleWeak`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IT-7565]: https://bethink.atlassian.net/browse/IT-7565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ