### PR TITLE
Switch npm publish from NPM_TOKEN to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -24,6 +24,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     permissions:
       contents: write
+      id-token: write
     env:
       FONT_AWESOME_AUTH_TOKEN: ${{ secrets.FONT_AWESOME_AUTH_TOKEN }}
     steps:
@@ -34,6 +35,8 @@ jobs:
         with:
           node-version-file: 'package.json'
           registry-url: 'https://registry.npmjs.org'
+      - name: Upgrade npm for Trusted Publishing
+        run: npm install -g npm@latest
       - uses: actions/cache@v5
         name: Cache node_modules
         id: cache-node-modules
@@ -65,8 +68,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish
-        # NODE_AUTH_TOKEN is read by the .npmrc written by setup-node (registry-url triggers this).
-        # See: https://github.com/actions/setup-node/blob/0355742c943ddb13ca8a6b700f824231caa91e75/docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # OIDC Trusted Publishing: npm exchanges the GitHub-issued id-token for a
+        # short-lived publish credential. No NPM_TOKEN needed.
+        # Requires id-token: write permission (above) and a Trusted Publisher
+        # configured on the package at npmjs.com.
+        run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary

- Replaces the long-lived `NPM_TOKEN` secret with npm OIDC Trusted Publishing — GitHub Actions mints a short-lived identity token on demand, no stored credential needed
- Adds `id-token: write` permission required for OIDC
- Upgrades npm to latest before publish (OIDC requires npm ≥ 11.5.1, which may not be bundled with the Node versions we support)
- Drops `NODE_AUTH_TOKEN` / `NPM_TOKEN` from the publish step
- Adds `--provenance` to attach a public build attestation linking the published package to this repo and CI run

The Trusted Publisher is already configured on npmjs.com for `bethinkpl/design-system → publish-npm.yml` so this is ready to merge and test.