### PR TITLE
Update release docs and pin npm version

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -36,7 +36,7 @@ jobs:
           node-version-file: 'package.json'
           registry-url: 'https://registry.npmjs.org'
       - name: Upgrade npm for Trusted Publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.17.0
       - uses: actions/cache@v5
         name: Cache node_modules
         id: cache-node-modules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,6 @@ yarn format:fix       # Auto-fix formatting
 
 ## Releasing
 
-1. Bump version in `package.json`.
-2. Wait for the `Build and Deploy Dist` GitHub Action to finish.
-3. Create a new tag and release on GitHub.
-4. Run `npm publish --access public`.
+Trigger the **Publish to NPM** GitHub Actions workflow manually: Actions → Publish to NPM → Run workflow → select `patch`, `minor`, or `major`.
+
+The workflow automatically bumps the version in `package.json`, builds and commits dist and Storybook, tags the commit, creates a GitHub release, and publishes to npm using OIDC Trusted Publishing (no `NPM_TOKEN` needed).

--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ If you use the review command more than once and the changes are not visible in 
 ## Releasing
 Build, deploy Storybook and publish to NPM by triggering the **Publish to NPM** action manually: Actions → Publish to NPM → Run workflow
 
-> **Note:** `NPM_TOKEN` must be set in repository secrets. The recommended token type is a [Granular Access Token](https://docs.npmjs.com/creating-and-viewing-access-tokens#creating-granular-access-tokens-on-the-website) scoped to this package only. Avoid running `npm publish` locally.
+> **Note:** Publishing uses [npm OIDC Trusted Publishing](https://docs.npmjs.com/generating-provenance-statements) — no `NPM_TOKEN` secret is needed. Avoid running `npm publish` locally.


### PR DESCRIPTION
## Summary

Follow-up to #616.

- **Pin npm to 11.17.0** in the publish workflow (separate commit) instead of `npm@latest`
- **README.md**: replaces the NPM_TOKEN note with a reference to OIDC Trusted Publishing
- **AGENTS.md**: replaces the outdated 4-step manual release process with a description of the automated workflow