### PR TITLE
fix: await file writes in importers to remove flaky test race

### DIFF
--- a/tools/importers/ImportColorsFromFigmaTokens.spec.ts
+++ b/tools/importers/ImportColorsFromFigmaTokens.spec.ts
@@ -93,8 +93,7 @@ const tokensFixture = {
 
 describe('ImportColorsFromFigmaTokens', () => {
 	it('ImportRawColors generates correct _raw.scss and _raw.json', async () => {
-		ImportRawColors(testConfig, rawColorsFixture);
-		await new Promise((r) => setTimeout(r, 1));
+		await ImportRawColors(testConfig, rawColorsFixture);
 
 		// --- _raw.scss ---
 		const scssContent = await promises.readFile(
@@ -160,8 +159,7 @@ describe('ImportColorsFromFigmaTokens', () => {
 	});
 
 	it('ImportTokens generates correct _tokens-variables.scss, _tokens.scss, and _tokens.json', async () => {
-		ImportTokens(testConfig, tokensFixture);
-		await new Promise((r) => setTimeout(r, 1));
+		await ImportTokens(testConfig, tokensFixture);
 
 		// --- _tokens-variables.scss ---
 		const variablesContent = await promises.readFile(
@@ -259,8 +257,7 @@ describe('ImportColorsFromFigmaTokens', () => {
 	});
 
 	it('ImportRawColors (theme mode) generates correct _raw-wnl.scss and _raw-wnl.json', async () => {
-		ImportRawColors(themeTestConfig, rawColorsFixture, 'wnl');
-		await new Promise((r) => setTimeout(r, 1));
+		await ImportRawColors(themeTestConfig, rawColorsFixture, 'wnl');
 
 		// --- _raw-wnl.scss ---
 		const scssContent = await promises.readFile(
@@ -296,8 +293,7 @@ describe('ImportColorsFromFigmaTokens', () => {
 	});
 
 	it('ImportTokens (theme mode) generates correct _tokens-wnl-variables.scss, _tokens-wnl.scss, and _tokens-wnl.json', async () => {
-		ImportTokens(themeTestConfig, tokensFixture, 'wnl');
-		await new Promise((r) => setTimeout(r, 1));
+		await ImportTokens(themeTestConfig, tokensFixture, 'wnl');
 
 		// --- _tokens-wnl-variables.scss ---
 		const variablesContent = await promises.readFile(

--- a/tools/importers/ImportColorsFromFigmaTokens.ts
+++ b/tools/importers/ImportColorsFromFigmaTokens.ts
@@ -65,11 +65,11 @@ export const validateRawSections = (wnl: FigmaRawColorsJson, bw: FigmaRawColorsJ
 	}
 };
 
-export const ImportRawColors = (
+export const ImportRawColors = async (
 	cfg: { destinationPath: string; files: ColorsBinFiles },
 	rawColorsJson: FigmaRawColorsJson,
 	themeName?: string,
-): void => {
+): Promise<void> => {
 	const isTheme = !!themeName;
 	const tab = isTheme ? '\t' : '';
 	const scssResult: Array<string> = [cssFileFirstLine(isTheme, themeName)];
@@ -136,15 +136,17 @@ export const ImportRawColors = (
 
 	if (scssResult.length <= 2) throw new Error('No colors to save');
 
-	arrayToFile(cfg.destinationPath + cfg.files.variablesRaw.destination, scssResult);
-	jsonToFile(cfg.destinationPath + cfg.files.variablesRaw.destinationJson, jsonResult);
+	await Promise.all([
+		arrayToFile(cfg.destinationPath + cfg.files.variablesRaw.destination, scssResult),
+		jsonToFile(cfg.destinationPath + cfg.files.variablesRaw.destinationJson, jsonResult),
+	]);
 };
 
-export const ImportTokens = (
+export const ImportTokens = async (
 	cfg: { destinationPath: string; files: ColorsBinFiles },
 	tokensJson: FigmaTokensJson,
 	themeName?: string,
-): void => {
+): Promise<void> => {
 	const isTheme = !!themeName;
 	const tab = isTheme ? '\t' : '';
 	const variablesResult: Array<string> = [cssFileFirstLine(isTheme, themeName)];
@@ -190,9 +192,11 @@ export const ImportTokens = (
 
 	if (scssResult.length === 0) throw new Error('No tokens to save');
 
-	arrayToFile(cfg.destinationPath + cfg.files.tokens.destinationVariables, variablesResult);
-	arrayToFile(cfg.destinationPath + cfg.files.tokens.destination, scssResult);
-	jsonToFile(cfg.destinationPath + cfg.files.tokens.destinationJson, jsonResult);
+	await Promise.all([
+		arrayToFile(cfg.destinationPath + cfg.files.tokens.destinationVariables, variablesResult),
+		arrayToFile(cfg.destinationPath + cfg.files.tokens.destination, scssResult),
+		jsonToFile(cfg.destinationPath + cfg.files.tokens.destinationJson, jsonResult),
+	]);
 };
 
 const run = async () => {
@@ -226,7 +230,7 @@ const run = async () => {
 		destinationPath: defaultConfig.destinationPath,
 		files: defaultConfig.base.files,
 	};
-	ImportRawColors(baseCfg, wnlColorsJson);
+	await ImportRawColors(baseCfg, wnlColorsJson);
 	console.log('Base raw colors imported successfully.');
 
 	const tokensJson: FigmaTokensJson | null = tokensPath
@@ -234,7 +238,7 @@ const run = async () => {
 		: null;
 
 	if (tokensJson) {
-		ImportTokens(baseCfg, tokensJson);
+		await ImportTokens(baseCfg, tokensJson);
 		console.log('Base tokens imported successfully.');
 	}
 
@@ -252,11 +256,11 @@ const run = async () => {
 
 		const themeCfg = { destinationPath: defaultConfig.destinationPath, files: theme.files };
 
-		ImportRawColors(themeCfg, themeColorsJson, theme.name);
+		await ImportRawColors(themeCfg, themeColorsJson, theme.name);
 		console.log(`Theme raw colors imported successfully for: ${theme.name}`);
 
 		if (tokensJson) {
-			ImportTokens(themeCfg, tokensJson, theme.name);
+			await ImportTokens(themeCfg, tokensJson, theme.name);
 			console.log(`Theme tokens imported successfully for: ${theme.name}`);
 		}
 	}

--- a/tools/importers/SynchronizeTypographyTokens.spec.ts
+++ b/tools/importers/SynchronizeTypographyTokens.spec.ts
@@ -39,8 +39,6 @@ describe('Typography Tokens', () => {
 			inputTokens.values.LMSDesignSystemTypography,
 		);
 
-		await new Promise((r) => setTimeout(r, 1));
-
 		let variableFileRaw = await promises.readFile(
 			tokensFilesConfig.destinationPath +
 				tokensFilesConfig.bin.files.variablesRaw.destinationVariables,

--- a/tools/importers/SynchronizeTypographyTokens.ts
+++ b/tools/importers/SynchronizeTypographyTokens.ts
@@ -39,10 +39,10 @@ import {
 
 dotenv.config();
 
-export const ImportTypographyVariables = (
+export const ImportTypographyVariables = async (
 	typographyConfigFile: TypographyConfigFile,
 	jsonTypography: Object,
-) => {
+): Promise<void> => {
 	let resultCss: Array<string> = [];
 	let resultScss: Array<string> = [];
 	let resultJsonCss: Dict<Array<IResultJsonObject>> = {};
@@ -132,27 +132,29 @@ export const ImportTypographyVariables = (
 		resultJsonCss[fontStyleKey].push(item);
 	});
 
-	arrayToFile(
-		typographyConfigFile.destinationPath +
-			typographyConfigFile.bin.files.variablesRaw.destinationVariablesCss,
-		resultCss,
-	);
-	arrayToFile(
-		typographyConfigFile.destinationPath +
-			typographyConfigFile.bin.files.variablesRaw.destinationVariables,
-		resultScss,
-	);
-	jsonToFile(
-		typographyConfigFile.destinationPath +
-			typographyConfigFile.bin.files.variablesRaw.destinationVariablesCssJson,
-		resultJsonCss,
-	);
+	await Promise.all([
+		arrayToFile(
+			typographyConfigFile.destinationPath +
+				typographyConfigFile.bin.files.variablesRaw.destinationVariablesCss,
+			resultCss,
+		),
+		arrayToFile(
+			typographyConfigFile.destinationPath +
+				typographyConfigFile.bin.files.variablesRaw.destinationVariables,
+			resultScss,
+		),
+		jsonToFile(
+			typographyConfigFile.destinationPath +
+				typographyConfigFile.bin.files.variablesRaw.destinationVariablesCssJson,
+			resultJsonCss,
+		),
+	]);
 };
 
-export const ImportTypographyTokens = (
+export const ImportTypographyTokens = async (
 	typographyConfigFile: TypographyConfigFile,
 	jsonTypography: any,
-) => {
+): Promise<void> => {
 	let resultScss: Array<ITypographyToken> = recursiveTokensReader(jsonTypography[tokensKey], '');
 	let resultJsonCss: Dict<Array<ITypographyToken>> = {};
 
@@ -164,15 +166,18 @@ export const ImportTypographyTokens = (
 		resultJsonCss[category].push(item);
 	});
 
-	arrayToMixinFile(
-		typographyConfigFile.destinationPath + typographyConfigFile.bin.files.tokens.destination,
-		[importVariables, ...buildTypographyTokensMixins(resultScss.flat())],
-	);
-	jsonToFile(
-		typographyConfigFile.destinationPath +
-			typographyConfigFile.bin.files.tokens.destinationJson,
-		resultJsonCss,
-	);
+	await Promise.all([
+		arrayToMixinFile(
+			typographyConfigFile.destinationPath +
+				typographyConfigFile.bin.files.tokens.destination,
+			[importVariables, ...buildTypographyTokensMixins(resultScss.flat())],
+		),
+		jsonToFile(
+			typographyConfigFile.destinationPath +
+				typographyConfigFile.bin.files.tokens.destinationJson,
+			resultJsonCss,
+		),
+	]);
 };
 
 function buildTypographyTokensMixins(tokens: Array<ITypographyToken>): Array<string> {
@@ -207,12 +212,12 @@ const SynchronizeTypographyTokensBin = async () => {
 		tokensFilesConfig.jsonBinApiUrl,
 	);
 
-	ImportTypographyVariables(
+	await ImportTypographyVariables(
 		tokensFilesConfig,
 		requestResponse.data.record.values.LMSDesignSystemTypography,
 	);
 
-	ImportTypographyTokens(
+	await ImportTypographyTokens(
 		tokensFilesConfig,
 		requestResponse.data.record.values.LMSDesignSystemTypography,
 	);

--- a/tools/importers/helpers/fileWriter.ts
+++ b/tools/importers/helpers/fileWriter.ts
@@ -1,10 +1,15 @@
 import { WriteStream, createWriteStream } from 'fs';
 
-export const arrayToFile = (filepath: string, content: Array<string>) => {
-	let file: WriteStream = createWriteStream(filepath);
-	file.on('error', function (err) {
-		console.error(err);
+/** Resolves once the stream has fully flushed to disk; rejects on write error. */
+const finished = (file: WriteStream): Promise<void> =>
+	new Promise((resolve, reject) => {
+		file.on('error', reject);
+		file.on('finish', resolve);
 	});
+
+export const arrayToFile = (filepath: string, content: Array<string>): Promise<void> => {
+	let file: WriteStream = createWriteStream(filepath);
+	const done = finished(file);
 
 	const noIndentationRules: RegExp = /root|}/i;
 	let hasFileIndentation = false;
@@ -18,13 +23,12 @@ export const arrayToFile = (filepath: string, content: Array<string>) => {
 		}
 	});
 	file.end();
+	return done;
 };
 
-export const arrayToMixinFile = (filepath: string, content: Array<string>) => {
+export const arrayToMixinFile = (filepath: string, content: Array<string>): Promise<void> => {
 	let file: WriteStream = createWriteStream(filepath);
-	file.on('error', function (err) {
-		console.error(err);
-	});
+	const done = finished(file);
 
 	const noIndentationRules: RegExp = /@mixin|@import|}/i;
 
@@ -36,13 +40,13 @@ export const arrayToMixinFile = (filepath: string, content: Array<string>) => {
 		file.write(hasLineIndentation ? '\t' + v + '\n' : v + '\n');
 	});
 	file.end();
+	return done;
 };
 
-export const jsonToFile = (filepath: string, content: Object) => {
+export const jsonToFile = (filepath: string, content: Object): Promise<void> => {
 	let file = createWriteStream(filepath);
-	file.on('error', function (err) {
-		console.error(err);
-	});
+	const done = finished(file);
 	file.write(JSON.stringify(content));
 	file.end();
+	return done;
 };


### PR DESCRIPTION
## Why

The `master` CI run [#28360122303](https://github.com/bethinkpl/design-system/actions/runs/28360122303/job/84012487644) failed in the **Run unit tests** step:

```
FAIL tools/importers/ImportColorsFromFigmaTokens.spec.ts > ImportTokens generates correct ...
Error: ENOENT: no such file or directory, open 'tools/importers/temp/_tokens-variables-test.scss'
```

A re-run on the same commit passed green — the signature of a flaky test, not a real defect.

## Root cause

The importer functions wrote files via `createWriteStream` (asynchronous, fire-and-forget — write errors were only `console.error`'d), and the specs waited a fixed `setTimeout(r, 1)` (1ms) before reading the files back with `readFile`. On a slow/loaded CI runner the stream hadn't created/flushed the file within 1ms, so `readFile` threw `ENOENT`.

## Fix

Make the writers signal completion deterministically instead of guessing with a sleep:

- `helpers/fileWriter.ts` — `arrayToFile`, `arrayToMixinFile`, `jsonToFile` now return a `Promise<void>` that resolves on the stream's `finish` event and **rejects on error** (the old silent `console.error` is what masked this failure).
- `ImportColorsFromFigmaTokens.ts` / `SynchronizeTypographyTokens.ts` — `ImportRawColors`, `ImportTokens`, `ImportTypographyVariables`, `ImportTypographyTokens` are now `async` and `await Promise.all([...])` their writes; the production `run()`/`...Bin()` callers `await` them too.
- Both spec files `await` the import calls directly; the arbitrary `setTimeout(r, 1)` waits are removed.

## Verification

- Importer specs: 5/5 consecutive runs green (previously reproducible flake under load)
- Full suite: 415/415 tests pass
- `yarn ts:check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)