### PR TITLE
Add x-small (1px) size to ContainerRibbon

### DIFF
--- a/lib/js/components/ContainerRibbon/ContainerRibbon.consts.ts
+++ b/lib/js/components/ContainerRibbon/ContainerRibbon.consts.ts
@@ -1,6 +1,7 @@
 import { Value } from '../../utils/type.utils';
 
 export const CONTAINER_RIBBON_SIZES = {
+	X_SMALL: 'x-small',
 	SMALL: 'small',
 	MEDIUM: 'medium',
 	LARGE: 'large',

--- a/lib/js/components/ContainerRibbon/ContainerRibbon.spec.ts
+++ b/lib/js/components/ContainerRibbon/ContainerRibbon.spec.ts
@@ -23,12 +23,15 @@ describe('ContainerRibbon', () => {
 		);
 	});
 
-	it('applies size classes correctly', () => {
-		const wrapper = mount(ContainerRibbon, {
-			props: { size: CONTAINER_RIBBON_SIZES.SMALL },
-		});
-		expect(wrapper.find('.ds-container-ribbon').classes()).toContain('-ds-size-small');
-	});
+	it.each(Object.values(CONTAINER_RIBBON_SIZES))(
+		'applies size class correctly for size "%s"',
+		(size) => {
+			const wrapper = mount(ContainerRibbon, {
+				props: { size },
+			});
+			expect(wrapper.find('.ds-container-ribbon').classes()).toContain(`-ds-size-${size}`);
+		},
+	);
 
 	it('applies color classes correctly', () => {
 		const wrapper = mount(ContainerRibbon, {

--- a/lib/js/components/ContainerRibbon/ContainerRibbon.vue
+++ b/lib/js/components/ContainerRibbon/ContainerRibbon.vue
@@ -2,6 +2,7 @@
 	<div
 		class="ds-container-ribbon"
 		:class="{
+			'-ds-size-x-small': size === CONTAINER_RIBBON_SIZES.X_SMALL,
 			'-ds-size-small': size === CONTAINER_RIBBON_SIZES.SMALL,
 			'-ds-size-medium': size === CONTAINER_RIBBON_SIZES.MEDIUM,
 			'-ds-size-large': size === CONTAINER_RIBBON_SIZES.LARGE,
@@ -38,6 +39,16 @@
 	}
 
 	// Size variants
+	&.-ds-size-x-small {
+		&.-ds-layout-vertical {
+			width: $border-xs;
+		}
+
+		&.-ds-layout-horizontal {
+			height: $border-xs;
+		}
+	}
+
 	&.-ds-size-small {
 		&.-ds-layout-vertical {
 			width: $border-s;


### PR DESCRIPTION
## Summary
- Add an `X_SMALL` (`x-small`, 1px) size variant to `ContainerRibbon`, using the existing `$border-xs` (1px) token for both vertical (`width`) and horizontal (`height`) layouts.
- Storybook select control picks up the new size automatically via `Object.values(CONTAINER_RIBBON_SIZES)`.
- Refactored the size test to `it.each(Object.values(CONTAINER_RIBBON_SIZES))` so every size is covered (and future sizes are covered automatically).

## Test plan
- [x] `npx vitest run lib/js/components/ContainerRibbon/ContainerRibbon.spec.ts` — all tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)