### PR TITLE
Add experimentalContent slot to Card

### DIFF
--- a/lib/js/components/Cards/Card/Card.spec.ts
+++ b/lib/js/components/Cards/Card/Card.spec.ts
@@ -55,6 +55,56 @@ describe('Card', () => {
 		expect(component.text()).toContain(footer);
 	});
 
+	it('should render experimentalContent slot', () => {
+		const experimentalContent = 'Wpłynąlem na suchego przestwór oceanu';
+		const component = createComponent({
+			slots: {
+				experimentalContent: () => [h('span', experimentalContent)],
+			},
+		});
+
+		expect(component.find('.ds-card__experimentalContent').exists()).toBe(true);
+		expect(component.find('.ds-card__experimentalContent').text()).toContain(
+			experimentalContent,
+		);
+	});
+
+	it('should skip standard slots when experimentalContent is used', () => {
+		const component = createComponent({
+			slots: {
+				header: () => [h('span', 'header')],
+				content: () => [h('span', 'content')],
+				footer: () => [h('span', 'footer')],
+				experimentalContent: () => [h('span', 'experimental')],
+			},
+		});
+
+		expect(component.find('.ds-card__header').exists()).toBe(false);
+		expect(component.find('.ds-card__content').exists()).toBe(false);
+		expect(component.find('.ds-card__footer').exists()).toBe(false);
+	});
+
+	it('should not render the slotsWrapper when experimentalContent is used', () => {
+		const component = createComponent({
+			slots: {
+				experimentalContent: () => [h('span', 'experimental')],
+			},
+		});
+
+		expect(component.find('.ds-card__slotsWrapper').exists()).toBe(false);
+	});
+
+	it('should still render the ribbon when experimentalContent is used', () => {
+		const component = createComponent({
+			props: { hasRibbon: true },
+			slots: {
+				experimentalContent: () => [h('span', 'experimental')],
+			},
+		});
+
+		expect(component.find('.ds-card__ribbon').exists()).toBe(true);
+	});
+
 	it('should render content slot with padding by default', () => {
 		const content = 'Wpłynąlem na suchego przestwór oceanu';
 		const component = createComponent({

--- a/lib/js/components/Cards/Card/Card.stories.ts
+++ b/lib/js/components/Cards/Card/Card.stories.ts
@@ -31,6 +31,9 @@ const StoryTemplate: StoryFn<typeof Card> = (args) => ({
 			<template v-if="args.footer" #footer>
 				<div v-html="args.footer" />
 			</template>
+			<template v-if="args.experimentalContent" #experimentalContent>
+				<div v-html="args.experimentalContent" />
+			</template>
 		</card>`,
 });
 
@@ -40,6 +43,7 @@ const args = {
 	header: 'header slot',
 	content: 'content slot that supports <b>HTML markup</b>',
 	footer: 'footer slot',
+	experimentalContent: '',
 	contentHasPadding: true,
 	headerHasPadding: false,
 	footerHasPadding: false,
@@ -65,6 +69,7 @@ const argTypes = {
 		control: 'text',
 	},
 	footer: { control: 'text' },
+	experimentalContent: { control: 'text' },
 	backgroundColor: {
 		control: 'select',
 		options: Object.values(CARD_BACKGROUND_COLORS),

--- a/lib/js/components/Cards/Card/Card.vue
+++ b/lib/js/components/Cards/Card/Card.vue
@@ -28,7 +28,12 @@
 			/>
 		</div>
 
+		<div v-if="$slots.experimentalContent" class="ds-card__experimentalContent">
+			<slot name="experimentalContent" />
+		</div>
+
 		<div
+			v-else
 			class="ds-card__slotsWrapper"
 			:class="{ '-ds-containerIsScrollable': isContentScrollable }"
 		>
@@ -108,6 +113,14 @@
 		&.-ds-containerIsScrollable {
 			overflow: hidden;
 		}
+	}
+
+	&__experimentalContent {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
+		// prevents excessive width due to child elements
+		min-width: 0;
 	}
 
 	&__header {
@@ -263,6 +276,7 @@ defineSlots<{
 	header?: () => any;
 	content?: () => any;
 	footer?: () => any;
+	experimentalContent?: () => any;
 }>();
 
 const ribbonLayout = computed(() => {


### PR DESCRIPTION
## Summary
Adds a new `experimentalContent` slot to the `Card` component — an escape hatch for dropping fully custom, unmanaged markup into the card body.

When `experimentalContent` is provided:
- the standard `header` / `content` / `footer` slots are **skipped**
- the padding props (`contentHasPadding`, `headerHasPadding`, `footerHasPadding`, `paddingSize`), `dividerUnderHeader`, and `isContentScrollable` have **no effect** (their bindings live entirely inside the `v-else` branch)
- the ribbon / loading bar still renders as card chrome (unchanged)

The slot renders in a minimal `ds-card__experimentalContent` wrapper that preserves the flex fill needed for the left-ribbon (row) layout, without any padding or overflow handling.

## Changes
- `Card.vue`: `experimentalContent` branch in the template, `defineSlots` entry, and a matching SCSS rule
- `Card.spec.ts`: tests for slot rendering, standard slots being skipped, `slotsWrapper` absence, and ribbon still rendering
- `Card.stories.ts`: `experimentalContent` text control added to the `Interactive` story

## Testing
- `npx vitest run` on Card spec — 29 tests pass
- `vue-tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)