### PR TITLE
Add large padding size (24px) to Well component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/lib/js/components/Well/Well.consts.ts
+++ b/lib/js/components/Well/Well.consts.ts
@@ -4,6 +4,7 @@ import { CONTAINER_RIBBON_COLORS, CONTAINER_RIBBON_SIZES } from '../ContainerRib
 export const WELL_PADDINGS = {
 	SMALL: 'small',
 	MEDIUM: 'medium',
+	LARGE: 'large',
 } as const;
 
 export type WellPadding = Value<typeof WELL_PADDINGS>;

--- a/lib/js/components/Well/Well.spec.ts
+++ b/lib/js/components/Well/Well.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { ComponentMountingOptions, mount } from '@vue/test-utils';
 
 import Well from './Well.vue';
-import { WELL_RIBBON_POSITIONS } from './Well.consts';
+import { WELL_PADDINGS, WELL_RIBBON_POSITIONS } from './Well.consts';
 
 describe('Well', () => {
 	const createComponent = (options: ComponentMountingOptions<typeof Well> = {}) => {
@@ -22,6 +22,14 @@ describe('Well', () => {
 		});
 
 		expect(component.find('.ds-well__content').text()).toContain(content);
+	});
+
+	it.each(Object.values(WELL_PADDINGS))('should set the padding class for %s', (padding) => {
+		const component = createComponent({
+			props: { padding },
+		});
+
+		expect(component.find('.ds-well').classes()).toContain(`-ds-${padding}`);
 	});
 
 	it('should not set no-radius class by default', () => {

--- a/lib/js/components/Well/Well.vue
+++ b/lib/js/components/Well/Well.vue
@@ -4,6 +4,7 @@
 		:class="[
 			colorClass,
 			{
+				'-ds-large': WELL_PADDINGS.LARGE === padding,
 				'-ds-medium': WELL_PADDINGS.MEDIUM === padding,
 				'-ds-small': WELL_PADDINGS.SMALL === padding,
 				'-ds-noRadius': !hasRadius,
@@ -142,6 +143,16 @@
 		position: absolute;
 		right: 0;
 		top: -10px;
+	}
+
+	&.-ds-large {
+		#{$root}__content {
+			padding: $space-12;
+		}
+
+		#{$root}__accessorySlot {
+			right: $space-12;
+		}
 	}
 
 	&.-ds-medium {


### PR DESCRIPTION
## Summary
- Add a `large` option to `WELL_PADDINGS` applying 24px (`$space-12`) padding to the content and offsetting the accessory slot to match, alongside the existing `small` (12px) and `medium` (16px) sizes.
- The Storybook `padding` control derives its options from `Object.values(WELL_PADDINGS)`, so `large` is selectable automatically — no story change needed.
- Add a parameterised spec (`it.each`) asserting each padding value applies its `-ds-<padding>` class (previously padding had no test coverage).
- Add a root `CLAUDE.md` that imports `AGENTS.md` so agent guidance (incl. the verification workflow) loads into context automatically.

## Verification
Per `agent-docs/verification.md`:
- `yarn format:fix` — clean
- `yarn test` — all passing (Well: 15 tests)
- `yarn ts:check` — clean
- `yarn lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)