### PR TITLE
LMS-3585 | Emit error event from DsImage on image load failure

### DIFF
--- a/lib/js/components/Image/Image.vue
+++ b/lib/js/components/Image/Image.vue
@@ -9,7 +9,7 @@
 			draggable="false"
 			loading="lazy"
 			:src="src"
-			@error="isLoading = false"
+			@error="onError"
 			@load="isLoading = false"
 		/>
 		<div v-if="isLoading" class="ds-image__loader">
@@ -73,12 +73,21 @@ export default defineComponent({
 			required: true,
 		},
 	},
+	emits: {
+		error: (event: Event) => event instanceof Event,
+	},
 	data() {
 		return {
 			isLoading: true,
 			IMAGE_FITS: Object.freeze(IMAGE_FITS),
 			SKELETON_RADIUS_SIZES: Object.freeze(SKELETON_RADIUS_SIZES),
 		};
+	},
+	methods: {
+		onError(event: Event) {
+			this.isLoading = false;
+			this.$emit('error', event);
+		},
 	},
 });
 </script>


### PR DESCRIPTION
Follow-up to wnl-platform#7837 (merged & released).

`ds-image` handled the native `<img>` `@error` internally and emitted nothing, so consumers couldn't detect a failed image and swap to a fallback source. It now emits an `error` event (forwarding the native `Event`) while keeping the existing loading behavior — backward-compatible.

`yarn ts:check` and `yarn lint:scripts` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)