### PR TITLE
Add moon-star icon

### DIFF
--- a/lib/js/icons/fontawesome.ts
+++ b/lib/js/icons/fontawesome.ts
@@ -134,6 +134,7 @@ import { faMemoCircleInfo } from '@fortawesome/pro-regular-svg-icons/faMemoCircl
 import { faMinus } from '@fortawesome/pro-regular-svg-icons/faMinus';
 import { faMobileRotate } from '@fortawesome/pro-regular-svg-icons/faMobileRotate';
 import { faMoneyBill1 } from '@fortawesome/pro-regular-svg-icons/faMoneyBill1';
+import { faMoonStar } from '@fortawesome/pro-regular-svg-icons/faMoonStar';
 import { faMusic } from '@fortawesome/pro-regular-svg-icons/faMusic';
 import { faNotes } from '@fortawesome/pro-regular-svg-icons/faNotes';
 import { faPaperclip } from '@fortawesome/pro-regular-svg-icons/faPaperclip';
@@ -228,6 +229,7 @@ import { faMessageXmark } from '@fortawesome/pro-regular-svg-icons/faMessageXmar
 import { faMessage } from '@fortawesome/pro-regular-svg-icons/faMessage';
 import { faSitemap as fasSitemap } from '@fortawesome/pro-solid-svg-icons/faSitemap';
 import { faMemo as fasMemo } from '@fortawesome/pro-solid-svg-icons/faMemo';
+import { faMoonStar as fasMoonStar } from '@fortawesome/pro-solid-svg-icons/faMoonStar';
 import { faSquareCheck as fasSquareCheck } from '@fortawesome/pro-solid-svg-icons/faSquareCheck';
 import { faSquareList as fasSquareList } from '@fortawesome/pro-solid-svg-icons/faSquareList';
 import { faSparkles as fasSparkles } from '@fortawesome/pro-solid-svg-icons/faSparkles';
@@ -462,6 +464,8 @@ export const FONTAWESOME_ICONS = {
 	FA_MINUS: faMinus,
 	FA_MOBILE_ROTATE: faMobileRotate,
 	FA_MONEY_BILL1: faMoneyBill1,
+	FA_MOON_STAR: faMoonStar,
+	FA_MOON_STAR_SOLID: fasMoonStar,
 	FA_MUSIC: faMusic,
 	FA_NOTES: faNotes,
 	FA_PAPER_PLANE: faPaperPlane,


### PR DESCRIPTION
## Summary

Adds the FontAwesome `moon-star` icon to the icon set, in both variants:

- `FA_MOON_STAR` — regular (outline)
- `FA_MOON_STAR_SOLID` — solid (filled)

These can be used together as an on/off indicator for a dark-theme toggle (regular = off, solid = on).

## Changes

- `lib/js/icons/fontawesome.ts` — import and register both variants, following the existing alphabetical/`fas` naming conventions.

## Verification

- `yarn ts:check` ✅
- `yarn lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)