### PR TITLE
Add sun-bright icon; drop sun-bright and moon-star solid variants

### DIFF
--- a/lib/js/icons/fontawesome.ts
+++ b/lib/js/icons/fontawesome.ts
@@ -230,12 +230,10 @@ import { faMessageXmark } from '@fortawesome/pro-regular-svg-icons/faMessageXmar
 import { faMessage } from '@fortawesome/pro-regular-svg-icons/faMessage';
 import { faSitemap as fasSitemap } from '@fortawesome/pro-solid-svg-icons/faSitemap';
 import { faMemo as fasMemo } from '@fortawesome/pro-solid-svg-icons/faMemo';
-import { faMoonStar as fasMoonStar } from '@fortawesome/pro-solid-svg-icons/faMoonStar';
 import { faSquareCheck as fasSquareCheck } from '@fortawesome/pro-solid-svg-icons/faSquareCheck';
 import { faSquareList as fasSquareList } from '@fortawesome/pro-solid-svg-icons/faSquareList';
 import { faSparkles as fasSparkles } from '@fortawesome/pro-solid-svg-icons/faSparkles';
 import { faStar as fasStar } from '@fortawesome/pro-solid-svg-icons/faStar';
-import { faSunBright as fasSunBright } from '@fortawesome/pro-solid-svg-icons/faSunBright';
 import { faStethoscope } from '@fortawesome/pro-regular-svg-icons/faStethoscope';
 import { faStopwatch as fasStopwach } from '@fortawesome/pro-solid-svg-icons/faStopwatch';
 import { faThumbsUp as fasThumbsUp } from '@fortawesome/pro-solid-svg-icons/faThumbsUp';
@@ -467,7 +465,6 @@ export const FONTAWESOME_ICONS = {
 	FA_MOBILE_ROTATE: faMobileRotate,
 	FA_MONEY_BILL1: faMoneyBill1,
 	FA_MOON_STAR: faMoonStar,
-	FA_MOON_STAR_SOLID: fasMoonStar,
 	FA_MUSIC: faMusic,
 	FA_NOTES: faNotes,
 	FA_PAPER_PLANE: faPaperPlane,
@@ -511,7 +508,6 @@ export const FONTAWESOME_ICONS = {
 	FA_STAR_SOLID: fasStar,
 	FA_STAR: faStar,
 	FA_SUN_BRIGHT: faSunBright,
-	FA_SUN_BRIGHT_SOLID: fasSunBright,
 	FA_STETHOSCOPE: faStethoscope,
 	FA_STOPWATCH_SOLID: fasStopwach,
 	FA_TAG: faTag,

--- a/lib/js/icons/fontawesome.ts
+++ b/lib/js/icons/fontawesome.ts
@@ -170,6 +170,7 @@ import { faSquareCheck } from '@fortawesome/pro-regular-svg-icons/faSquareCheck'
 import { faSquareList } from '@fortawesome/pro-regular-svg-icons/faSquareList';
 import { faSquareMinus } from '@fortawesome/pro-regular-svg-icons/faSquareMinus';
 import { faStar } from '@fortawesome/pro-regular-svg-icons/faStar';
+import { faSunBright } from '@fortawesome/pro-regular-svg-icons/faSunBright';
 import { faTag } from '@fortawesome/pro-regular-svg-icons/faTag';
 import { faTags } from '@fortawesome/pro-regular-svg-icons/faTags';
 import { faText } from '@fortawesome/pro-regular-svg-icons/faText';
@@ -234,6 +235,7 @@ import { faSquareCheck as fasSquareCheck } from '@fortawesome/pro-solid-svg-icon
 import { faSquareList as fasSquareList } from '@fortawesome/pro-solid-svg-icons/faSquareList';
 import { faSparkles as fasSparkles } from '@fortawesome/pro-solid-svg-icons/faSparkles';
 import { faStar as fasStar } from '@fortawesome/pro-solid-svg-icons/faStar';
+import { faSunBright as fasSunBright } from '@fortawesome/pro-solid-svg-icons/faSunBright';
 import { faStethoscope } from '@fortawesome/pro-regular-svg-icons/faStethoscope';
 import { faStopwatch as fasStopwach } from '@fortawesome/pro-solid-svg-icons/faStopwatch';
 import { faThumbsUp as fasThumbsUp } from '@fortawesome/pro-solid-svg-icons/faThumbsUp';
@@ -508,6 +510,8 @@ export const FONTAWESOME_ICONS = {
 	FA_SQUARE_SOLID: fasSquare,
 	FA_STAR_SOLID: fasStar,
 	FA_STAR: faStar,
+	FA_SUN_BRIGHT: faSunBright,
+	FA_SUN_BRIGHT_SOLID: fasSunBright,
 	FA_STETHOSCOPE: faStethoscope,
 	FA_STOPWATCH_SOLID: fasStopwach,
 	FA_TAG: faTag,


### PR DESCRIPTION
## Summary
- Add `FA_SUN_BRIGHT` (regular) FontAwesome icon to `lib/js/icons/fontawesome.ts`
- Remove the solid variants `FA_SUN_BRIGHT_SOLID` and `FA_MOON_STAR_SOLID`, keeping only the regular variants

> [!NOTE]
> `FA_MOON_STAR_SOLID` was previously merged to `master` in #631; this PR removes it, so any downstream references to it will need updating.

## Verification
- `yarn format:fix` — clean
- `yarn ts:check` — clean
- `yarn lint` — clean
- `yarn test` — 510 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)