### PR TITLE
Allow router-link and nuxt-link in Button `as` prop

### DIFF
--- a/lib/js/components/Buttons/Button/Button.vue
+++ b/lib/js/components/Buttons/Button/Button.vue
@@ -102,7 +102,7 @@ const {
 	iconLeft?: IconItem | null;
 	iconRight?: IconItem | null;
 	elevation?: ButtonElevation | string;
-	as?: 'button' | 'a' | 'span';
+	as?: 'button' | 'a' | 'span' | 'router-link' | 'nuxt-link';
 }>();
 
 const iconSize = computed((): IconSize => {


### PR DESCRIPTION
Widens the `as` prop union on `Button` from `'button' | 'a' | 'span'` to also accept `'router-link'` and `'nuxt-link'`, so the button can render as a client-side navigation component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)