### PR TITLE
Add z-index to Card left ribbon

### DIFF
--- a/lib/js/components/Cards/Card/Card.vue
+++ b/lib/js/components/Cards/Card/Card.vue
@@ -197,6 +197,10 @@
 			left: 0;
 			position: absolute;
 			top: 0;
+			// keeps the ribbon above content elements with `position: relative` and no z-index.
+			// the default leaves room for content to layer within itself (1-9); override via
+			// `--ds-card-ribbon-z-index` when content needs a higher stacking order.
+			z-index: var(--ds-card-ribbon-z-index, 10);
 		}
 	}
 }


### PR DESCRIPTION
## Problem

The left ribbon (`ribbonPosition="left"`) is absolutely positioned and is the **first** child of `.ds-card`. Positioned siblings with `z-index: auto` paint in DOM order, so any card content with `position: relative` and no `z-index` was painting on top of the ribbon and covering it.

## Change

```scss
z-index: var(--ds-card-ribbon-z-index, 10);
```

- **Default `10`** rather than `1`, so content has 1–9 available for layering within itself without jumping above the ribbon.
- **Exposed as a CSS custom property** so consumers can raise it if their content genuinely needs a higher stacking order. An SCSS variable wouldn't help here — it's compile-time, so it's unreachable for anyone consuming the published package. Naming follows the existing `--ds-<component>-<thing>` convention (`--ds-well-border-color`, `--ds-banner-title-color`).

## Notes

- Only affects the left-ribbon variant; the top ribbon is a normal flex item and needs nothing.
- `.ds-card` is not a stacking context (`position: relative; z-index: auto`), so the ribbon's `10` participates in the ancestor context. That's well below this repo's global layer floor (`$z-index-overlay: 51`), so it can't reach app chrome. Making the card `isolation: isolate` would contain it fully, but that's a behavior change for every consumer (inline-rendered dropdowns/tooltips would start clipping to the card's layer), so it's deliberately left out.
- No unit test — this is pure CSS in a scoped SFC block, which jsdom doesn't compute. (`--ds-magic-fill` has coverage only because Button sets it via a JS style binding.)

## Verification

`yarn format:fix`, `yarn test` (510 passed), `yarn ts:check`, `yarn lint` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)