### PR TITLE
IT-7640 | Add DrawerHeader supporting slot and Drawer/DrawerHeader backgroundColor

### DIFF
--- a/lib/js/components/Drawer/Drawer.consts.ts
+++ b/lib/js/components/Drawer/Drawer.consts.ts
@@ -4,3 +4,12 @@ export const DRAWER_POSITIONS = {
 } as const;
 
 export type DrawerPosition = (typeof DRAWER_POSITIONS)[keyof typeof DRAWER_POSITIONS];
+
+export const DRAWER_BACKGROUND_COLORS = {
+	NONE: 'none',
+	DEFAULT: 'default',
+	NEUTRAL: 'neutral',
+} as const;
+
+export type DrawerBackgroundColor =
+	(typeof DRAWER_BACKGROUND_COLORS)[keyof typeof DRAWER_BACKGROUND_COLORS];

--- a/lib/js/components/Drawer/Drawer.spec.ts
+++ b/lib/js/components/Drawer/Drawer.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import Drawer from './Drawer.vue';
+import { DRAWER_BACKGROUND_COLORS, DrawerBackgroundColor } from './Drawer.consts';
+
+const createComponent = (props = {}, slots = {}) => {
+	return mount(Drawer, {
+		props,
+		slots,
+	});
+};
+
+describe('Drawer', () => {
+	describe('backgroundColor', () => {
+		it.each([
+			[DRAWER_BACKGROUND_COLORS.DEFAULT, '-ds-backgroundDefault'],
+			[DRAWER_BACKGROUND_COLORS.NEUTRAL, '-ds-backgroundNeutral'],
+		])('should set the %s background class', (backgroundColor, expectedClass) => {
+			const component = createComponent({ backgroundColor });
+
+			expect(component.find('.ds-drawer').classes()).toContain(expectedClass);
+		});
+
+		it.each([undefined, DRAWER_BACKGROUND_COLORS.NONE])(
+			'should not set any background class when backgroundColor is %s',
+			(backgroundColor?: DrawerBackgroundColor) => {
+				const component = createComponent({ backgroundColor });
+
+				const classes = component.find('.ds-drawer').classes();
+
+				expect(classes).not.toContain('-ds-backgroundDefault');
+				expect(classes).not.toContain('-ds-backgroundNeutral');
+			},
+		);
+	});
+});

--- a/lib/js/components/Drawer/Drawer.stories.ts
+++ b/lib/js/components/Drawer/Drawer.stories.ts
@@ -1,5 +1,5 @@
 import Drawer from './Drawer.vue';
-import { DRAWER_POSITIONS } from './Drawer.consts';
+import { DRAWER_BACKGROUND_COLORS, DRAWER_POSITIONS } from './Drawer.consts';
 
 import { Args, ArgTypes, Meta, StoryFn } from '@storybook/vue3';
 
@@ -14,7 +14,7 @@ const StoryTemplate: StoryFn<typeof Drawer> = (args) => ({
 		return args;
 	},
 	template: `<div style="height: 300px; width: 200px;">
-		<drawer :position="position" :sticky-header="stickyHeader" :sticky-footer="stickyFooter">
+		<drawer :position="position" :sticky-header="stickyHeader" :sticky-footer="stickyFooter" :background-color="backgroundColor">
 		<template v-slot:header><div style="background-color: var(--raw-gray-100)">Header<br><br></div></template>
 		<div>Content<br>Content<br>Content<br>Content<br>Content<br>Content<br>Content<br>Content<br>Content<br>Content<br>Content<br>Content<br>Content<br>Content<br>Content<br>Content<br>Content<br></div>
 		<template v-slot:footer><div style="background-color: var(--raw-gray-100)">Footer<br><br></div></template>
@@ -28,12 +28,17 @@ const args = {
 	position: DRAWER_POSITIONS.RIGHT,
 	stickyHeader: true,
 	stickyFooter: true,
+	backgroundColor: DRAWER_BACKGROUND_COLORS.NONE,
 } as Args;
 
 const argTypes = {
 	position: {
 		control: 'select',
 		options: Object.values(DRAWER_POSITIONS),
+	},
+	backgroundColor: {
+		control: 'select',
+		options: Object.values(DRAWER_BACKGROUND_COLORS),
 	},
 } as ArgTypes;
 

--- a/lib/js/components/Drawer/Drawer.vue
+++ b/lib/js/components/Drawer/Drawer.vue
@@ -1,5 +1,8 @@
 <template>
-	<div class="ds-drawer scrollable-container" :class="{ [positionClassName]: true }">
+	<div
+		class="ds-drawer scrollable-container"
+		:class="[positionClassName, backgroundColorClassName]"
+	>
 		<div v-if="$slots.header && stickyHeader" class="ds-drawer__header -ds-sticky">
 			<slot name="header" />
 		</div>
@@ -48,6 +51,14 @@
 		}
 	}
 
+	&.-ds-backgroundDefault {
+		background-color: $color-default-background;
+	}
+
+	&.-ds-backgroundNeutral {
+		background-color: $color-neutral-background;
+	}
+
 	&__header,
 	&__footer {
 		flex-shrink: 0;
@@ -73,7 +84,12 @@
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
 
-import { DRAWER_POSITIONS, DrawerPosition } from './Drawer.consts';
+import {
+	DRAWER_BACKGROUND_COLORS,
+	DRAWER_POSITIONS,
+	DrawerBackgroundColor,
+	DrawerPosition,
+} from './Drawer.consts';
 
 export default defineComponent({
 	name: 'Drawer',
@@ -93,6 +109,13 @@ export default defineComponent({
 			type: Boolean,
 			default: true,
 		},
+		backgroundColor: {
+			type: String as PropType<DrawerBackgroundColor>,
+			default: DRAWER_BACKGROUND_COLORS.NONE,
+			validator(backgroundColor: DrawerBackgroundColor) {
+				return Object.values(DRAWER_BACKGROUND_COLORS).includes(backgroundColor);
+			},
+		},
 	},
 	computed: {
 		positionClassName(): string {
@@ -101,6 +124,16 @@ export default defineComponent({
 			}
 
 			return '-ds-positionRight';
+		},
+		backgroundColorClassName(): string | null {
+			switch (this.backgroundColor) {
+				case DRAWER_BACKGROUND_COLORS.DEFAULT:
+					return '-ds-backgroundDefault';
+				case DRAWER_BACKGROUND_COLORS.NEUTRAL:
+					return '-ds-backgroundNeutral';
+				default:
+					return null;
+			}
 		},
 	},
 });

--- a/lib/js/components/Drawer/DrawerHeader/DrawerHeader.consts.ts
+++ b/lib/js/components/Drawer/DrawerHeader/DrawerHeader.consts.ts
@@ -5,3 +5,11 @@ export const DRAWER_HEADER_TITLE_COLORS = {
 
 export type DrawerHeaderTitleColor =
 	(typeof DRAWER_HEADER_TITLE_COLORS)[keyof typeof DRAWER_HEADER_TITLE_COLORS];
+
+export const DRAWER_HEADER_BACKGROUND_COLORS = {
+	NONE: 'none',
+	DEFAULT: 'default',
+} as const;
+
+export type DrawerHeaderBackgroundColor =
+	(typeof DRAWER_HEADER_BACKGROUND_COLORS)[keyof typeof DRAWER_HEADER_BACKGROUND_COLORS];

--- a/lib/js/components/Drawer/DrawerHeader/DrawerHeader.spec.ts
+++ b/lib/js/components/Drawer/DrawerHeader/DrawerHeader.spec.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { mount } from '@vue/test-utils';
 import DrawerHeader from './DrawerHeader.vue';
 import { IconButton } from '../../../';
+import {
+	DRAWER_HEADER_BACKGROUND_COLORS,
+	DrawerHeaderBackgroundColor,
+} from './DrawerHeader.consts';
 
 const createComponent = (props = {}, slots = {}) => {
 	return mount(DrawerHeader, {
@@ -84,5 +88,26 @@ describe('DrawerHeader', () => {
 			expect(supportingIndex).toBe(titleWrapperIndex + 1);
 			expect(supportingIndex).toBe(children.length - 2);
 		});
+	});
+
+	describe('backgroundColor', () => {
+		it('should set the default background class when backgroundColor is default', () => {
+			const component = createComponent({
+				backgroundColor: DRAWER_HEADER_BACKGROUND_COLORS.DEFAULT,
+			});
+
+			expect(component.find('.ds-drawerHeader').classes()).toContain('-ds-backgroundDefault');
+		});
+
+		it.each([undefined, DRAWER_HEADER_BACKGROUND_COLORS.NONE])(
+			'should not set any background class when backgroundColor is %s',
+			(backgroundColor?: DrawerHeaderBackgroundColor) => {
+				const component = createComponent({ backgroundColor });
+
+				expect(component.find('.ds-drawerHeader').classes()).not.toContain(
+					'-ds-backgroundDefault',
+				);
+			},
+		);
 	});
 });

--- a/lib/js/components/Drawer/DrawerHeader/DrawerHeader.spec.ts
+++ b/lib/js/components/Drawer/DrawerHeader/DrawerHeader.spec.ts
@@ -59,34 +59,15 @@ describe('DrawerHeader', () => {
 	});
 
 	describe('supporting slot', () => {
-		it('should not render anything when the slot is not provided', () => {
-			const component = createComponent({ hasDivider: true });
-
-			const children = Array.from(component.element.children) as Array<Element>;
-
-			expect(children).toHaveLength(2);
-			expect(children[0].classList.contains('ds-drawerHeader__titleWrapper')).toBeTruthy();
-		});
-
-		it('should render the slot content between the title wrapper and the divider', () => {
+		it('should render the slot content inside the header wrapper', () => {
 			const component = createComponent(
-				{ hasDivider: true },
+				{},
 				{ supporting: '<span class="supporting-content">Supporting</span>' },
 			);
 
-			const supporting = component.find('.supporting-content');
+			const headerWrapper = component.find('.ds-drawerHeader__headerWrapper').element;
 
-			expect(supporting.exists()).toBeTruthy();
-			expect(supporting.text()).toBe('Supporting');
-
-			const children = Array.from(component.element.children) as Array<Element>;
-			const titleWrapperIndex = children.findIndex((child) =>
-				child.classList.contains('ds-drawerHeader__titleWrapper'),
-			);
-			const supportingIndex = children.indexOf(supporting.element);
-
-			expect(supportingIndex).toBe(titleWrapperIndex + 1);
-			expect(supportingIndex).toBe(children.length - 2);
+			expect(component.find('.supporting-content').element.parentElement).toBe(headerWrapper);
 		});
 	});
 

--- a/lib/js/components/Drawer/DrawerHeader/DrawerHeader.spec.ts
+++ b/lib/js/components/Drawer/DrawerHeader/DrawerHeader.spec.ts
@@ -3,9 +3,10 @@ import { mount } from '@vue/test-utils';
 import DrawerHeader from './DrawerHeader.vue';
 import { IconButton } from '../../../';
 
-const createComponent = (props = {}) => {
+const createComponent = (props = {}, slots = {}) => {
 	return mount(DrawerHeader, {
 		props,
+		slots,
 	});
 };
 
@@ -50,6 +51,38 @@ describe('DrawerHeader', () => {
 			await backButton.trigger('click');
 
 			expect(component.emitted().backClicked).toHaveLength(1);
+		});
+	});
+
+	describe('supporting slot', () => {
+		it('should not render anything when the slot is not provided', () => {
+			const component = createComponent({ hasDivider: true });
+
+			const children = Array.from(component.element.children) as Array<Element>;
+
+			expect(children).toHaveLength(2);
+			expect(children[0].classList.contains('ds-drawerHeader__titleWrapper')).toBeTruthy();
+		});
+
+		it('should render the slot content between the title wrapper and the divider', () => {
+			const component = createComponent(
+				{ hasDivider: true },
+				{ supporting: '<span class="supporting-content">Supporting</span>' },
+			);
+
+			const supporting = component.find('.supporting-content');
+
+			expect(supporting.exists()).toBeTruthy();
+			expect(supporting.text()).toBe('Supporting');
+
+			const children = Array.from(component.element.children) as Array<Element>;
+			const titleWrapperIndex = children.findIndex((child) =>
+				child.classList.contains('ds-drawerHeader__titleWrapper'),
+			);
+			const supportingIndex = children.indexOf(supporting.element);
+
+			expect(supportingIndex).toBe(titleWrapperIndex + 1);
+			expect(supportingIndex).toBe(children.length - 2);
 		});
 	});
 });

--- a/lib/js/components/Drawer/DrawerHeader/DrawerHeader.stories.ts
+++ b/lib/js/components/Drawer/DrawerHeader/DrawerHeader.stories.ts
@@ -6,6 +6,7 @@ import { DRAWER_HEADER_TITLE_COLORS } from './DrawerHeader.consts';
 import SlotPlaceholder, {
 	SLOT_PLACEHOLDER_SIZES,
 } from '../../../../../.storybook/SlotPlaceholder/SlotPlaceholder.vue';
+import { toRefs } from 'vue';
 
 export default {
 	title: 'Components/Drawer/DrawerHeader',
@@ -15,12 +16,10 @@ export default {
 const StoryTemplate: StoryFn<typeof DrawerHeader> = (args) => ({
 	components: { DrawerHeader, SlotPlaceholder },
 	setup() {
-		return args;
-	},
-	data() {
 		return {
-			ICONS: Object.freeze(ICONS),
-			SLOT_PLACEHOLDER_SIZES: Object.freeze(SLOT_PLACEHOLDER_SIZES),
+			...toRefs(args),
+			ICONS,
+			SLOT_PLACEHOLDER_SIZES,
 		};
 	},
 	template: `

--- a/lib/js/components/Drawer/DrawerHeader/DrawerHeader.stories.ts
+++ b/lib/js/components/Drawer/DrawerHeader/DrawerHeader.stories.ts
@@ -39,10 +39,10 @@ const StoryTemplate: StoryFn<typeof DrawerHeader> = (args) => ({
 			:has-back-button="hasBackButton"
 		>
 			<template #actions v-if="actions">
-				<div v-html="actions" />
+				<slot-placeholder :label="actions" :size="SLOT_PLACEHOLDER_SIZES.SMALL" />
 			</template>
 			<template #titleTrailing v-if="titleTrailing">
-				<div v-html="titleTrailing" />
+				<slot-placeholder :label="titleTrailing" :size="SLOT_PLACEHOLDER_SIZES.SMALL" />
 			</template>
 			<template #supporting v-if="supporting">
 				<slot-placeholder :label="supporting" :size="SLOT_PLACEHOLDER_SIZES.SMALL" />

--- a/lib/js/components/Drawer/DrawerHeader/DrawerHeader.stories.ts
+++ b/lib/js/components/Drawer/DrawerHeader/DrawerHeader.stories.ts
@@ -3,6 +3,9 @@ import DrawerHeader from './DrawerHeader.vue';
 import { Args, ArgTypes, Meta, StoryFn } from '@storybook/vue3';
 import { ICONS } from '../../Icons/Icon';
 import { DRAWER_HEADER_TITLE_COLORS } from './DrawerHeader.consts';
+import SlotPlaceholder, {
+	SLOT_PLACEHOLDER_SIZES,
+} from '../../../../../.storybook/SlotPlaceholder/SlotPlaceholder.vue';
 
 export default {
 	title: 'Components/Drawer/DrawerHeader',
@@ -10,13 +13,14 @@ export default {
 } as Meta<typeof DrawerHeader>;
 
 const StoryTemplate: StoryFn<typeof DrawerHeader> = (args) => ({
-	components: { DrawerHeader },
+	components: { DrawerHeader, SlotPlaceholder },
 	setup() {
 		return args;
 	},
 	data() {
 		return {
 			ICONS: Object.freeze(ICONS),
+			SLOT_PLACEHOLDER_SIZES: Object.freeze(SLOT_PLACEHOLDER_SIZES),
 		};
 	},
 	template: `
@@ -40,6 +44,9 @@ const StoryTemplate: StoryFn<typeof DrawerHeader> = (args) => ({
 			<template #titleTrailing v-if="titleTrailing">
 				<div v-html="titleTrailing" />
 			</template>
+			<template #supporting v-if="supporting">
+				<slot-placeholder :label="supporting" :size="SLOT_PLACEHOLDER_SIZES.SMALL" />
+			</template>
 		</drawer-header>`,
 });
 
@@ -59,6 +66,7 @@ const args = {
 	isSecondLevel: false,
 	actions: 'actions slot',
 	titleTrailing: 'trailing slot',
+	supporting: 'supporting slot',
 	hasBackButton: false,
 } as Args;
 
@@ -82,6 +90,7 @@ const argTypes = {
 	isClosable: { control: 'boolean' },
 	actions: { control: 'text' },
 	titleTrailing: { control: 'text' },
+	supporting: { control: 'text' },
 	hasBackButton: { control: 'boolean' },
 } as ArgTypes;
 

--- a/lib/js/components/Drawer/DrawerHeader/DrawerHeader.stories.ts
+++ b/lib/js/components/Drawer/DrawerHeader/DrawerHeader.stories.ts
@@ -2,7 +2,7 @@ import DrawerHeader from './DrawerHeader.vue';
 
 import { Args, ArgTypes, Meta, StoryFn } from '@storybook/vue3';
 import { ICONS } from '../../Icons/Icon';
-import { DRAWER_HEADER_TITLE_COLORS } from './DrawerHeader.consts';
+import { DRAWER_HEADER_BACKGROUND_COLORS, DRAWER_HEADER_TITLE_COLORS } from './DrawerHeader.consts';
 import SlotPlaceholder, {
 	SLOT_PLACEHOLDER_SIZES,
 } from '../../../../../.storybook/SlotPlaceholder/SlotPlaceholder.vue';
@@ -36,6 +36,7 @@ const StoryTemplate: StoryFn<typeof DrawerHeader> = (args) => ({
 			:title-ellipsis="titleEllipsis"
 			:title="title"
 			:has-back-button="hasBackButton"
+			:background-color="backgroundColor"
 		>
 			<template #actions v-if="actions">
 				<slot-placeholder :label="actions" :size="SLOT_PLACEHOLDER_SIZES.SMALL" />
@@ -67,6 +68,7 @@ const args = {
 	titleTrailing: 'trailing slot',
 	supporting: 'supporting slot',
 	hasBackButton: false,
+	backgroundColor: DRAWER_HEADER_BACKGROUND_COLORS.NONE,
 } as Args;
 
 const argTypes = {
@@ -91,6 +93,10 @@ const argTypes = {
 	titleTrailing: { control: 'text' },
 	supporting: { control: 'text' },
 	hasBackButton: { control: 'boolean' },
+	backgroundColor: {
+		control: 'select',
+		options: Object.values(DRAWER_HEADER_BACKGROUND_COLORS),
+	},
 } as ArgTypes;
 
 Interactive.argTypes = argTypes;

--- a/lib/js/components/Drawer/DrawerHeader/DrawerHeader.vue
+++ b/lib/js/components/Drawer/DrawerHeader/DrawerHeader.vue
@@ -5,68 +5,73 @@
 			'-ds-backgroundDefault': backgroundColor === DRAWER_HEADER_BACKGROUND_COLORS.DEFAULT,
 		}"
 	>
-		<div class="ds-drawerHeader__titleWrapper">
-			<ds-button
-				v-if="isSecondLevel"
-				:icon-left="ICONS.FA_CHEVRON_LEFT"
-				:type="BUTTON_TYPES.TEXT"
-				class="ds-drawerHeader__secondLevel"
-				@click="$emit('backClicked')"
-			>
-				{{ t('ds.globals.back') }}
-			</ds-button>
-			<div :class="{ '-ds-hidden': isSecondLevel }" class="ds-drawerHeader__firstLevel">
-				<icon-button
-					v-if="hasBackButton"
-					:size="ICON_BUTTON_SIZES.MEDIUM"
-					:icon="ICONS.FA_CHEVRON_LEFT"
+		<div class="ds-drawerHeader__headerWrapper">
+			<div class="ds-drawerHeader__titleWrapper">
+				<ds-button
+					v-if="isSecondLevel"
+					:icon-left="ICONS.FA_CHEVRON_LEFT"
+					:type="BUTTON_TYPES.TEXT"
+					class="ds-drawerHeader__secondLevel"
 					@click="$emit('backClicked')"
-				/>
-				<div class="ds-drawerHeader__textWrapper">
-					<span
-						v-if="eyebrowText"
-						:class="{
-							'-ds-isInteractive': isInteractiveEyebrow,
-							'-ds-ellipsis': eyebrowEllipsis,
-						}"
-						class="ds-drawerHeader__eyebrow"
-						@click="isInteractiveEyebrow && $emit('eyebrowClicked')"
-					>
-						{{ eyebrowText }}
-					</span>
-					<div class="ds-drawerHeader__title">
-						<icon
-							v-if="leftIcon"
-							:icon="leftIcon"
-							:size="ICON_SIZES.X_SMALL"
-							class="ds-drawerHeader__leftIcon"
-						/>
+				>
+					{{ t('ds.globals.back') }}
+				</ds-button>
+				<div :class="{ '-ds-hidden': isSecondLevel }" class="ds-drawerHeader__firstLevel">
+					<icon-button
+						v-if="hasBackButton"
+						:size="ICON_BUTTON_SIZES.MEDIUM"
+						:icon="ICONS.FA_CHEVRON_LEFT"
+						@click="$emit('backClicked')"
+					/>
+					<div class="ds-drawerHeader__textWrapper">
 						<span
-							v-if="title"
-							class="ds-drawerHeader__titleText"
-							:class="{ '-ds-ellipsis': titleEllipsis, [`-ds-${titleColor}`]: true }"
-							:title="titleEllipsis ? title : undefined"
-							>{{ title }}</span
+							v-if="eyebrowText"
+							:class="{
+								'-ds-isInteractive': isInteractiveEyebrow,
+								'-ds-ellipsis': eyebrowEllipsis,
+							}"
+							class="ds-drawerHeader__eyebrow"
+							@click="isInteractiveEyebrow && $emit('eyebrowClicked')"
 						>
-						<chip v-if="chipLabel" :label="chipLabel" />
-						<div v-if="$slots.titleTrailing">
-							<slot name="titleTrailing" />
+							{{ eyebrowText }}
+						</span>
+						<div class="ds-drawerHeader__title">
+							<icon
+								v-if="leftIcon"
+								:icon="leftIcon"
+								:size="ICON_SIZES.X_SMALL"
+								class="ds-drawerHeader__leftIcon"
+							/>
+							<span
+								v-if="title"
+								class="ds-drawerHeader__titleText"
+								:class="{
+									'-ds-ellipsis': titleEllipsis,
+									[`-ds-${titleColor}`]: true,
+								}"
+								:title="titleEllipsis ? title : undefined"
+								>{{ title }}</span
+							>
+							<chip v-if="chipLabel" :label="chipLabel" />
+							<div v-if="$slots.titleTrailing">
+								<slot name="titleTrailing" />
+							</div>
 						</div>
 					</div>
 				</div>
+				<div v-if="$slots.actions" class="ds-drawerHeader__actions">
+					<slot name="actions" />
+				</div>
+				<icon-button
+					v-if="isClosable"
+					:color="ICON_COLORS.NEUTRAL"
+					:icon="ICONS.FA_XMARK"
+					:size="ICON_BUTTON_SIZES.MEDIUM"
+					@click="$emit('close')"
+				/>
 			</div>
-			<div v-if="$slots.actions" class="ds-drawerHeader__actions">
-				<slot name="actions" />
-			</div>
-			<icon-button
-				v-if="isClosable"
-				:color="ICON_COLORS.NEUTRAL"
-				:icon="ICONS.FA_XMARK"
-				:size="ICON_BUTTON_SIZES.MEDIUM"
-				@click="$emit('close')"
-			/>
+			<slot name="supporting" />
 		</div>
-		<slot name="supporting" />
 		<divider v-if="hasDivider" :size="DIVIDER_SIZES.L" :prominence="DIVIDER_PROMINENCES.WEAK" />
 	</div>
 </template>
@@ -84,6 +89,10 @@ $minimal-drawer-header-height: 58px;
 
 	&.-ds-backgroundDefault {
 		background-color: $color-default-background;
+	}
+
+	&__headerWrapper {
+		padding: $space-6;
 	}
 
 	&__secondLevel {
@@ -159,7 +168,6 @@ $minimal-drawer-header-height: 58px;
 		display: flex;
 		justify-content: space-between;
 		min-height: $minimal-drawer-header-height;
-		padding: $space-6;
 	}
 
 	&__actions {

--- a/lib/js/components/Drawer/DrawerHeader/DrawerHeader.vue
+++ b/lib/js/components/Drawer/DrawerHeader/DrawerHeader.vue
@@ -1,5 +1,10 @@
 <template>
-	<div class="ds-drawerHeader">
+	<div
+		class="ds-drawerHeader"
+		:class="{
+			'-ds-backgroundDefault': backgroundColor === DRAWER_HEADER_BACKGROUND_COLORS.DEFAULT,
+		}"
+	>
 		<div class="ds-drawerHeader__titleWrapper">
 			<ds-button
 				v-if="isSecondLevel"
@@ -76,6 +81,10 @@ $minimal-drawer-header-height: 58px;
 .ds-drawerHeader {
 	display: flex;
 	flex-direction: column;
+
+	&.-ds-backgroundDefault {
+		background-color: $color-default-background;
+	}
 
 	&__secondLevel {
 		position: absolute !important; // it is required so firstLevel content does not make component wider when hidden, and important is needed so component does not change its width when button was clicked
@@ -165,7 +174,12 @@ import Divider, { DIVIDER_PROMINENCES, DIVIDER_SIZES } from '../../Divider';
 import IconButton, { ICON_BUTTON_SIZES } from '../../Buttons/IconButton';
 import Chip from '../../Chip';
 import Icon, { ICON_COLORS, ICON_SIZES, ICONS, IconItem } from '../../Icons/Icon';
-import { DRAWER_HEADER_TITLE_COLORS, DrawerHeaderTitleColor } from './DrawerHeader.consts';
+import {
+	DRAWER_HEADER_BACKGROUND_COLORS,
+	DRAWER_HEADER_TITLE_COLORS,
+	DrawerHeaderBackgroundColor,
+	DrawerHeaderTitleColor,
+} from './DrawerHeader.consts';
 import { useLegacyI18n } from '../../../composables/useLegacyI18n';
 
 const {
@@ -181,6 +195,7 @@ const {
 	hasDivider = false,
 	isSecondLevel = false,
 	hasBackButton = false,
+	backgroundColor = DRAWER_HEADER_BACKGROUND_COLORS.NONE,
 } = defineProps<{
 	eyebrowText?: string | null;
 	isInteractiveEyebrow?: boolean;
@@ -194,6 +209,7 @@ const {
 	hasDivider?: boolean;
 	isSecondLevel?: boolean;
 	hasBackButton?: boolean;
+	backgroundColor?: DrawerHeaderBackgroundColor;
 }>();
 
 defineSlots<{

--- a/lib/js/components/Drawer/DrawerHeader/DrawerHeader.vue
+++ b/lib/js/components/Drawer/DrawerHeader/DrawerHeader.vue
@@ -92,6 +92,7 @@ $minimal-drawer-header-height: 58px;
 	}
 
 	&__headerWrapper {
+		min-height: $minimal-drawer-header-height;
 		padding: $space-6;
 	}
 
@@ -167,7 +168,6 @@ $minimal-drawer-header-height: 58px;
 		column-gap: $space-2;
 		display: flex;
 		justify-content: space-between;
-		min-height: $minimal-drawer-header-height;
 	}
 
 	&__actions {

--- a/lib/js/components/Drawer/DrawerHeader/DrawerHeader.vue
+++ b/lib/js/components/Drawer/DrawerHeader/DrawerHeader.vue
@@ -61,6 +61,7 @@
 				@click="$emit('close')"
 			/>
 		</div>
+		<slot name="supporting" />
 		<divider v-if="hasDivider" :size="DIVIDER_SIZES.L" :prominence="DIVIDER_PROMINENCES.WEAK" />
 	</div>
 </template>

--- a/lib/js/components/Drawer/DrawerHeader/DrawerHeader.vue
+++ b/lib/js/components/Drawer/DrawerHeader/DrawerHeader.vue
@@ -159,96 +159,54 @@ $minimal-drawer-header-height: 58px;
 }
 </style>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
-
-import Button from '../../Buttons/Button/Button.vue';
-import Divider from '../../Divider/Divider.vue';
-import IconButton from '../../Buttons/IconButton/IconButton.vue';
-import Chip from '../../Chip/Chip.vue';
-import Icon from '../../Icons/Icon/Icon.vue';
-import { BUTTON_TYPES } from '../../Buttons/Button';
-import { ICON_COLORS, ICON_SIZES, ICONS } from '../../Icons/Icon';
-import { DIVIDER_PROMINENCES, DIVIDER_SIZES } from '../../Divider';
-import { ICON_BUTTON_SIZES } from '../../Buttons/IconButton';
+<script setup lang="ts">
+import DsButton, { BUTTON_TYPES } from '../../Buttons/Button';
+import Divider, { DIVIDER_PROMINENCES, DIVIDER_SIZES } from '../../Divider';
+import IconButton, { ICON_BUTTON_SIZES } from '../../Buttons/IconButton';
+import Chip from '../../Chip';
+import Icon, { ICON_COLORS, ICON_SIZES, ICONS, IconItem } from '../../Icons/Icon';
 import { DRAWER_HEADER_TITLE_COLORS, DrawerHeaderTitleColor } from './DrawerHeader.consts';
 import { useLegacyI18n } from '../../../composables/useLegacyI18n';
 
-export default defineComponent({
-	name: 'DrawerHeader',
-	components: {
-		DsButton: Button,
-		Divider,
-		Icon,
-		IconButton,
-		Chip,
-	},
-	props: {
-		eyebrowText: {
-			type: String,
-			default: null,
-		},
-		isInteractiveEyebrow: {
-			type: Boolean,
-			default: false,
-		},
-		eyebrowEllipsis: {
-			type: Boolean,
-			default: false,
-		},
-		title: {
-			type: String,
-			default: null,
-		},
-		titleEllipsis: {
-			type: Boolean,
-			default: false,
-		},
-		titleColor: {
-			type: String as PropType<DrawerHeaderTitleColor>,
-			default: DRAWER_HEADER_TITLE_COLORS.NEUTRAL_STRONG,
-		},
-		leftIcon: {
-			type: [Object, null],
-			default: null,
-		},
-		chipLabel: {
-			type: String,
-			default: null,
-		},
-		isClosable: {
-			type: Boolean,
-			default: true,
-		},
-		hasDivider: {
-			type: Boolean,
-			default: false,
-		},
-		isSecondLevel: {
-			type: Boolean,
-			default: false,
-		},
-		hasBackButton: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	// TODO fix me when touching this file
-	// eslint-disable-next-line vue/require-emit-validator
-	emits: ['backClicked', 'close', 'eyebrowClicked'],
-	setup() {
-		const { t } = useLegacyI18n();
+const {
+	eyebrowText = null,
+	isInteractiveEyebrow = false,
+	eyebrowEllipsis = false,
+	title = null,
+	titleEllipsis = false,
+	titleColor = DRAWER_HEADER_TITLE_COLORS.NEUTRAL_STRONG,
+	leftIcon = null,
+	chipLabel = null,
+	isClosable = true,
+	hasDivider = false,
+	isSecondLevel = false,
+	hasBackButton = false,
+} = defineProps<{
+	eyebrowText?: string | null;
+	isInteractiveEyebrow?: boolean;
+	eyebrowEllipsis?: boolean;
+	title?: string | null;
+	titleEllipsis?: boolean;
+	titleColor?: DrawerHeaderTitleColor;
+	leftIcon?: IconItem | null;
+	chipLabel?: string | null;
+	isClosable?: boolean;
+	hasDivider?: boolean;
+	isSecondLevel?: boolean;
+	hasBackButton?: boolean;
+}>();
 
-		return {
-			t,
-			BUTTON_TYPES,
-			DIVIDER_SIZES,
-			DIVIDER_PROMINENCES,
-			ICONS,
-			ICON_BUTTON_SIZES,
-			ICON_SIZES,
-			ICON_COLORS,
-		};
-	},
-});
+defineSlots<{
+	titleTrailing?: () => any;
+	actions?: () => any;
+	supporting?: () => any;
+}>();
+
+defineEmits<{
+	backClicked: [];
+	close: [];
+	eyebrowClicked: [];
+}>();
+
+const { t } = useLegacyI18n();
 </script>

--- a/lib/js/icons/fontawesome.ts
+++ b/lib/js/icons/fontawesome.ts
@@ -208,6 +208,7 @@ import { faCheck as fasCheck } from '@fortawesome/pro-solid-svg-icons/faCheck';
 import { faCircleCheck as fasCircleCheck } from '@fortawesome/pro-solid-svg-icons/faCircleCheck';
 import { faCirclePlay as fasCirclePlay } from '@fortawesome/pro-solid-svg-icons/faCirclePlay';
 import { faComment as fasComment } from '@fortawesome/pro-solid-svg-icons/faComment';
+import { faComments as fasComments } from '@fortawesome/pro-solid-svg-icons/faComments';
 import { faCompass as fasCompass } from '@fortawesome/pro-solid-svg-icons/faCompass';
 import { faExclamation as fasExclamation } from '@fortawesome/pro-solid-svg-icons/faExclamation';
 import { faFileLines as fasFileLines } from '@fortawesome/pro-solid-svg-icons/faFileLines';
@@ -371,6 +372,7 @@ export const FONTAWESOME_ICONS = {
 	FA_COMMENT: faComment,
 	FA_COMMENTS_QUESTION_CHECK: faCommentsQuestionCheck,
 	FA_COMMENTS_QUESTION: faCommentsQuestion,
+	FA_COMMENTS_SOLID: fasComments,
 	FA_COMMENTS: faComments,
 	FA_COMPASS_SOLID: fasCompass,
 	FA_COMPRESS: faCompress,


### PR DESCRIPTION
## `supporting` slot on `DrawerHeader`

Adds a `supporting` slot to `DrawerHeader` for content that belongs to the header but sits below the title row (filters, tabs, a search field, …).

```vue
<drawer-header title="Users" has-divider>
	<template #supporting>
		<filters-row />
	</template>
</drawer-header>
```

The slot is declared in `defineSlots` alongside the existing `titleTrailing` and `actions`, and is rendered unconditionally (no `v-if="$slots.supporting"` wrapper), so nothing is emitted when it isn't provided.

### `__headerWrapper` and where the padding lives

`__titleWrapper` used to own the header's `$space-6` padding and its `min-height`. Once there's a `supporting` slot below the title row, that padding no longer belongs to the title row alone — so both declarations moved up to a new `__headerWrapper` wrapping `__titleWrapper` + the slot:

```
.ds-drawerHeader
├── .ds-drawerHeader__headerWrapper   ← padding: $space-6; min-height: 58px
│   ├── .ds-drawerHeader__titleWrapper
│   └── <slot name="supporting" />
└── <divider v-if="hasDivider" />
```

**`min-height` had to move together with the padding to keep the header the same size.** `box-sizing: border-box` is inherited from `html`, so whichever element carries both declarations determines the total height. With `$space-6` = 12px (`$space-base` is 2px):

| | computed min header height |
|---|---|
| before — `__titleWrapper { min-height: 58px; padding: 12px }` | 58px |
| padding moved alone — wrapper padded, `min-height` on the now-unpadded title row | 58 + 24 = 82px |
| now — `__headerWrapper { min-height: 58px; padding: 12px }` | 58px |

So headers without a `supporting` slot are pixel-identical to `master`.

One nuance: the 58px floor now applies to the title row **plus** the supporting slot, rather than to the title row alone. The title row's tallest child is the close `IconButton` at 32px, against a 34px content-box floor (58 − 24), so when a `supporting` slot is provided the title row renders at its natural 32px instead of being stretched by 2px. Only reachable through the new slot, so nothing existing shifts.

The `<divider>` stays a direct child of the root, outside `__headerWrapper`. It was already full-bleed before this change (the root element has no padding of its own), so its rendering is unchanged — it just needs to stay outside the wrapper to remain that way.

The practical effect of the wrapper is that **supporting content is inset by `$space-6`, aligned with the title**, instead of sitting flush against the drawer edges as it would have as a root-level sibling.

## `backgroundColor` prop on `Drawer` and `DrawerHeader`

Both components were fully transparent — `Drawer`'s only color declaration was `border-color` — so consumers had to wrap or override them to get an opaque drawer surface, and a sticky `DrawerHeader` let scrolling content show through behind it.

| component | values | default |
|---|---|---|
| `Drawer` | `none` / `default` / `neutral` | `none` |
| `DrawerHeader` | `none` / `default` | `none` |

`default` → `$color-default-background`, `neutral` → `$color-neutral-background` — the same surface tokens `Card`'s `backgroundColor` uses. `none` emits no modifier class and no `background-color` declaration.

**Both default to `none`, so nothing renders differently until a consumer opts in** — no visual breaking change.

Each component gets its own enum (`DRAWER_BACKGROUND_COLORS`, `DRAWER_HEADER_BACKGROUND_COLORS`) rather than sharing one, since the value sets differ and that matches how `Card`, `MenuItem`, and `RichListItem` each define their own. Both consts files are already `export *`-ed from `lib/js/index.ts`, so the new consts and types are public without touching the barrel.

Two things worth knowing when using this:

- `default` and `neutral` are distinct in both themes (`white`/`gray-50` light, `black`/`gray-950` dark), so the two `Drawer` values won't look the same.
- An opaque `Drawer` paired with `DrawerHeader backgroundColor="none"` still shows content scrolling behind the sticky header — setting the header to `default` is what makes it opaque.

## Also in here

- **Migrated `DrawerHeader` to `<script setup>`** — `defineProps` with destructured defaults, `defineSlots`, `defineEmits`. Behavior-preserving; verified against the `@vue/compiler-sfc` output in both dev and prod mode (boolean prop casting, `isClosable`'s `default: true`, and `titleColor`'s default all compile to the same runtime behavior). The dropped `name: 'DrawerHeader'` is covered by the compiler-emitted `__name`, which both KeepAlive's `getComponentName` and test-utils name matching fall back to.
- **`Drawer` stays Options API** — the `backgroundColor` prop follows the existing `position` prop's shape (`PropType` + `default` + `validator`). Migrating it was out of scope here.
- **New `Drawer.spec.ts`** — there was no `Drawer` spec before this branch. Scoped to the new prop only.
- **New `FA_COMMENTS_SOLID` icon** — `faComments` from `pro-solid-svg-icons`, registered in `FONTAWESOME_ICONS` next to the existing regular `FA_COMMENTS` (same `_SOLID`-suffix convention as `FA_COMMENT_SOLID`). Additive and unrelated to the Drawer work — it just rode along on this branch.
- **Story cleanup** — the `actions` / `titleTrailing` / `supporting` slot controls now render `SlotPlaceholder` instead of `v-html`, so the slot boundaries are actually visible in Storybook. `data()` → `toRefs(args)` in `setup` so the controls stay reactive (Storybook wraps `storyContext.args` in `reactive()` before calling the story fn); `Object.freeze(ICONS)` was only there to dodge `data()`'s reactive conversion and is no longer needed. Both stories bind their props by hand in a template string, so `backgroundColor` is wired up there explicitly.

## Verification

`yarn format:fix`, `yarn test` (518 passed / 48 files — `DrawerHeader` 8, `Drawer` 4), `yarn ts:check`, `yarn lint`, `yarn format:check` — all clean.

The `supporting` slot's coverage is a single test asserting the slot content's parent is `__headerWrapper` — the structural guarantee the padding depends on. The padding itself isn't asserted: scoped SCSS isn't applied under jsdom, so class membership is the only proxy available, and confirming it visually needs Storybook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

