### PR TITLE
IT-7662: Ecommerce changes

### DIFF
--- a/lib/js/components/Cards/Card/Card.consts.ts
+++ b/lib/js/components/Cards/Card/Card.consts.ts
@@ -7,6 +7,7 @@ import {
 
 export const CARD_PADDING_SIZES = {
 	SMALL: 'small',
+	MEDIUM: 'medium',
 	LARGE: 'large',
 } as const;
 
@@ -15,9 +16,26 @@ export type CardPaddingSize = Value<typeof CARD_PADDING_SIZES>;
 export const CARD_BACKGROUND_COLORS = {
 	DEFAULT: 'default',
 	NEUTRAL: 'neutral',
+	NONE: 'none',
 } as const;
 
 export type CardBackgroundColor = Value<typeof CARD_BACKGROUND_COLORS>;
+
+export const CARD_ELEVATIONS = {
+	DEFAULT: 'default',
+	TOP: 'top',
+	NONE: 'none',
+} as const;
+
+export type CardElevation = Value<typeof CARD_ELEVATIONS>;
+
+export const CARD_RADIUSES = {
+	ALL: 'all',
+	TOP: 'top',
+	NONE: 'none',
+} as const;
+
+export type CardRadius = Value<typeof CARD_RADIUSES>;
 
 export const CARD_RIBBON_COLORS = CONTAINER_RIBBON_COLORS;
 

--- a/lib/js/components/Cards/Card/Card.spec.ts
+++ b/lib/js/components/Cards/Card/Card.spec.ts
@@ -3,11 +3,35 @@ import { ComponentMountingOptions, mount } from '@vue/test-utils';
 import { h } from 'vue';
 
 import Card from './Card.vue';
-import { CARD_BACKGROUND_COLORS, CARD_PADDING_SIZES } from './Card.consts';
+import {
+	CARD_BACKGROUND_COLORS,
+	CARD_ELEVATIONS,
+	CARD_PADDING_SIZES,
+	CARD_RADIUSES,
+	CardBackgroundColor,
+	CardElevation,
+	CardPaddingSize,
+	CardRadius,
+} from './Card.consts';
 
 describe('Card', () => {
 	const createComponent = (options: ComponentMountingOptions<typeof Card> = {}) => {
 		return mount(Card, options);
+	};
+
+	// asserts that exactly one modifier out of a variant group is applied
+	const expectOnlyModifier = (
+		classes: Array<string>,
+		modifiers: Array<string>,
+		expectedModifier: string | null,
+	) => {
+		modifiers.forEach((modifier) => {
+			if (modifier === expectedModifier) {
+				expect(classes).toContain(modifier);
+			} else {
+				expect(classes).not.toContain(modifier);
+			}
+		});
 	};
 
 	it('should create', () => {
@@ -198,62 +222,95 @@ describe('Card', () => {
 		);
 	});
 
-	it('should set large padding class', () => {
-		const component = createComponent({
-			props: { paddingSize: CARD_PADDING_SIZES.LARGE },
-		});
+	const PADDING_MODIFIERS = ['-ds-paddingMedium', '-ds-paddingLarge'];
 
-		expect(component.find('.ds-card').classes()).toContain('-ds-paddingLarge');
+	it.each<[CardPaddingSize, string | null]>([
+		[CARD_PADDING_SIZES.SMALL, null],
+		[CARD_PADDING_SIZES.MEDIUM, '-ds-paddingMedium'],
+		[CARD_PADDING_SIZES.LARGE, '-ds-paddingLarge'],
+	])('should set the padding class for paddingSize %s', (paddingSize, expectedModifier) => {
+		const component = createComponent({ props: { paddingSize } });
+
+		expectOnlyModifier(
+			component.find('.ds-card').classes(),
+			PADDING_MODIFIERS,
+			expectedModifier,
+		);
 	});
 
-	it('should not set large padding class', () => {
-		const component = createComponent({
-			props: { paddingSize: CARD_PADDING_SIZES.SMALL },
-		});
-
-		expect(component.find('.ds-card').classes()).not.toContain('-ds-paddingLarge');
-	});
-
-	it('should not set flat class by default', () => {
+	it('should not set any padding class by default', () => {
 		const component = createComponent();
 
-		expect(component.find('.ds-card').classes()).not.toContain('-ds-flat');
+		expectOnlyModifier(component.find('.ds-card').classes(), PADDING_MODIFIERS, null);
 	});
 
-	it('should set flat class', () => {
-		const component = createComponent({
-			props: { isFlat: true },
-		});
+	const ELEVATION_MODIFIERS = ['-ds-elevationTop', '-ds-elevationNone'];
 
-		expect(component.find('.ds-card').classes()).toContain('-ds-flat');
+	it.each<[CardElevation, string | null]>([
+		[CARD_ELEVATIONS.DEFAULT, null],
+		[CARD_ELEVATIONS.TOP, '-ds-elevationTop'],
+		[CARD_ELEVATIONS.NONE, '-ds-elevationNone'],
+	])('should set the elevation class for elevation %s', (elevation, expectedModifier) => {
+		const component = createComponent({ props: { elevation } });
+
+		expectOnlyModifier(
+			component.find('.ds-card').classes(),
+			ELEVATION_MODIFIERS,
+			expectedModifier,
+		);
 	});
 
-	it('should not set no-radius class by default', () => {
+	it('should not set any elevation class by default', () => {
 		const component = createComponent();
 
-		expect(component.find('.ds-card').classes()).not.toContain('-ds-noRadius');
+		expectOnlyModifier(component.find('.ds-card').classes(), ELEVATION_MODIFIERS, null);
 	});
 
-	it('should set no-radius class when hasRadius is false', () => {
-		const component = createComponent({
-			props: { hasRadius: false },
-		});
+	const RADIUS_MODIFIERS = ['-ds-radiusTop', '-ds-radiusNone'];
 
-		expect(component.find('.ds-card').classes()).toContain('-ds-noRadius');
+	it.each<[CardRadius, string | null]>([
+		[CARD_RADIUSES.ALL, null],
+		[CARD_RADIUSES.TOP, '-ds-radiusTop'],
+		[CARD_RADIUSES.NONE, '-ds-radiusNone'],
+	])('should set the radius class for radius %s', (radius, expectedModifier) => {
+		const component = createComponent({ props: { radius } });
+
+		expectOnlyModifier(
+			component.find('.ds-card').classes(),
+			RADIUS_MODIFIERS,
+			expectedModifier,
+		);
 	});
 
-	it('should not set neutral background class by default', () => {
+	it('should not set any radius class by default', () => {
 		const component = createComponent();
 
-		expect(component.find('.ds-card').classes()).not.toContain('-ds-backgroundNeutral');
+		expectOnlyModifier(component.find('.ds-card').classes(), RADIUS_MODIFIERS, null);
 	});
 
-	it('should set neutral background class when backgroundColor is neutral', () => {
-		const component = createComponent({
-			props: { backgroundColor: CARD_BACKGROUND_COLORS.NEUTRAL },
-		});
+	const BACKGROUND_MODIFIERS = ['-ds-backgroundNeutral', '-ds-backgroundNone'];
 
-		expect(component.find('.ds-card').classes()).toContain('-ds-backgroundNeutral');
+	it.each<[CardBackgroundColor, string | null]>([
+		[CARD_BACKGROUND_COLORS.DEFAULT, null],
+		[CARD_BACKGROUND_COLORS.NEUTRAL, '-ds-backgroundNeutral'],
+		[CARD_BACKGROUND_COLORS.NONE, '-ds-backgroundNone'],
+	])(
+		'should set the background class for backgroundColor %s',
+		(backgroundColor, expectedModifier) => {
+			const component = createComponent({ props: { backgroundColor } });
+
+			expectOnlyModifier(
+				component.find('.ds-card').classes(),
+				BACKGROUND_MODIFIERS,
+				expectedModifier,
+			);
+		},
+	);
+
+	it('should not set any background class by default', () => {
+		const component = createComponent();
+
+		expectOnlyModifier(component.find('.ds-card').classes(), BACKGROUND_MODIFIERS, null);
 	});
 
 	it('should not give the ribbon a radius when only hasRibbonRadius is set', () => {
@@ -266,25 +323,25 @@ describe('Card', () => {
 
 	it('should give the ribbon a radius when hasRibbonRadius and card has no radius', () => {
 		const component = createComponent({
-			props: { hasRibbon: true, hasRibbonRadius: true, hasRadius: false },
+			props: { hasRibbon: true, hasRibbonRadius: true, radius: CARD_RADIUSES.NONE },
 		});
 
 		expect(component.find('.-ds-radius-bottom').exists()).toBe(true);
 	});
 
-	it('should not give the ribbon a radius when hasRadius is false but hasRibbonRadius is false', () => {
+	it('should not give the ribbon a radius when radius is none but hasRibbonRadius is false', () => {
 		const component = createComponent({
-			props: { hasRibbon: true, hasRibbonRadius: false, hasRadius: false },
+			props: { hasRibbon: true, hasRibbonRadius: false, radius: CARD_RADIUSES.NONE },
 		});
 
 		expect(component.find('.-ds-radius-bottom').exists()).toBe(false);
 	});
 
-	it('should give the ribbon a radius when hasRibbonRadius and card is flat', () => {
+	it('should not give the ribbon a radius when the card is rounded at the top', () => {
 		const component = createComponent({
-			props: { hasRibbon: true, hasRibbonRadius: true, isFlat: true },
+			props: { hasRibbon: true, hasRibbonRadius: true, radius: CARD_RADIUSES.TOP },
 		});
 
-		expect(component.find('.-ds-radius-bottom').exists()).toBe(true);
+		expect(component.find('.-ds-radius-bottom').exists()).toBe(false);
 	});
 });

--- a/lib/js/components/Cards/Card/Card.stories.ts
+++ b/lib/js/components/Cards/Card/Card.stories.ts
@@ -3,6 +3,8 @@ import Card from './Card.vue';
 import { Args, ArgTypes, Meta, StoryFn } from '@storybook/vue3';
 import {
 	CARD_BACKGROUND_COLORS,
+	CARD_ELEVATIONS,
+	CARD_RADIUSES,
 	CARD_RIBBON_COLORS,
 	CARD_RIBBON_POSITIONS,
 	CARD_RIBBON_SIZES,
@@ -50,7 +52,8 @@ const args = {
 	paddingSize: CARD_PADDING_SIZES.SMALL,
 	dividerUnderHeader: false,
 	hasRibbon: false,
-	hasRadius: true,
+	elevation: CARD_ELEVATIONS.DEFAULT,
+	radius: CARD_RADIUSES.ALL,
 	backgroundColor: CARD_BACKGROUND_COLORS.DEFAULT,
 	ribbonPosition: CARD_RIBBON_POSITIONS.TOP,
 	ribbonSize: CARD_RIBBON_SIZES.MEDIUM,
@@ -59,7 +62,6 @@ const args = {
 	hasLoadingBar: false,
 	loadingBarColor: LOADING_BAR_COLORS.NEUTRAL_HEAVY,
 	loadingBarTime: '0',
-	isFlat: false,
 	isContentScrollable: false,
 } as Args;
 
@@ -70,6 +72,14 @@ const argTypes = {
 	},
 	footer: { control: 'text' },
 	experimentalContent: { control: 'text' },
+	elevation: {
+		control: 'select',
+		options: Object.values(CARD_ELEVATIONS),
+	},
+	radius: {
+		control: 'select',
+		options: Object.values(CARD_RADIUSES),
+	},
 	backgroundColor: {
 		control: 'select',
 		options: Object.values(CARD_BACKGROUND_COLORS),

--- a/lib/js/components/Cards/Card/Card.vue
+++ b/lib/js/components/Cards/Card/Card.vue
@@ -3,12 +3,16 @@
 		:class="[
 			'ds-card',
 			{
+				'-ds-paddingMedium': paddingSize === CARD_PADDING_SIZES.MEDIUM,
 				'-ds-paddingLarge': paddingSize === CARD_PADDING_SIZES.LARGE,
 				'-ds-leftRibbon':
 					hasRibbon && !hasLoadingBar && ribbonPosition === CARD_RIBBON_POSITIONS.LEFT,
-				'-ds-flat': isFlat,
-				'-ds-noRadius': !hasRadius,
+				'-ds-elevationTop': elevation === CARD_ELEVATIONS.TOP,
+				'-ds-elevationNone': elevation === CARD_ELEVATIONS.NONE,
+				'-ds-radiusTop': radius === CARD_RADIUSES.TOP,
+				'-ds-radiusNone': radius === CARD_RADIUSES.NONE,
 				'-ds-backgroundNeutral': backgroundColor === CARD_BACKGROUND_COLORS.NEUTRAL,
+				'-ds-backgroundNone': backgroundColor === CARD_BACKGROUND_COLORS.NONE,
 			},
 		]"
 	>
@@ -80,23 +84,36 @@
 	$root: &;
 	$card-border-radius: $radius-m;
 
+	background-color: $color-default-background;
+	border-radius: $card-border-radius;
+	box-shadow: $shadow-s;
 	display: flex;
 	flex-direction: column;
 	position: relative;
 	width: inherit;
 
-	&:not(.-ds-flat) {
-		background-color: $color-default-background;
-		border-radius: $card-border-radius;
-		box-shadow: $shadow-s;
+	&.-ds-backgroundNeutral {
+		background-color: $color-neutral-background;
+	}
 
-		&.-ds-backgroundNeutral {
-			background-color: $color-neutral-background;
-		}
+	&.-ds-backgroundNone {
+		background-color: transparent;
+	}
 
-		&.-ds-noRadius {
-			border-radius: 0;
-		}
+	&.-ds-elevationTop {
+		box-shadow: $shadow-top-s;
+	}
+
+	&.-ds-elevationNone {
+		box-shadow: none;
+	}
+
+	&.-ds-radiusTop {
+		border-radius: $card-border-radius $card-border-radius 0 0;
+	}
+
+	&.-ds-radiusNone {
+		border-radius: 0;
 	}
 
 	&.-ds-leftRibbon {
@@ -127,6 +144,10 @@
 		&.-ds-withPadding {
 			padding: $space-8;
 
+			#{$root}.-ds-paddingMedium & {
+				padding: $space-12 $space-12 $space-8;
+			}
+
 			#{$root}.-ds-paddingLarge & {
 				padding: $space-16 $space-16 $space-8;
 			}
@@ -136,6 +157,10 @@
 	&__headerDivider {
 		&.-ds-withHorizontalMargin {
 			margin: 0 $space-8;
+
+			#{$root}.-ds-paddingMedium & {
+				margin: 0 $space-12;
+			}
 
 			#{$root}.-ds-paddingLarge & {
 				margin: 0 $space-16;
@@ -148,6 +173,10 @@
 
 		&.-ds-withPadding {
 			padding: $space-8;
+
+			#{$root}.-ds-paddingMedium & {
+				padding: $space-8 $space-12;
+			}
 
 			#{$root}.-ds-paddingLarge & {
 				padding: $space-8 $space-16;
@@ -164,6 +193,10 @@
 		&.-ds-withPadding {
 			padding: 0 $space-8 $space-8;
 
+			#{$root}.-ds-paddingMedium & {
+				padding: 0 $space-12 $space-12;
+			}
+
 			#{$root}.-ds-paddingLarge & {
 				padding: 0 $space-16 $space-16;
 			}
@@ -176,20 +209,21 @@
 		display: flex;
 		flex-shrink: 0;
 
-		#{$root}:not(.-ds-flat) & {
+		#{$root}:not(.-ds-radiusNone) & {
 			border-top-left-radius: $card-border-radius;
 			border-top-right-radius: $card-border-radius;
 			overflow: hidden;
 		}
 
-		#{$root}:not(.-ds-flat).-ds-leftRibbon & {
-			border-bottom-left-radius: $card-border-radius;
+		#{$root}:not(.-ds-radiusNone).-ds-leftRibbon & {
 			border-top-left-radius: $card-border-radius;
 			border-top-right-radius: 0;
 		}
 
-		#{$root}:not(.-ds-flat).-ds-noRadius & {
-			border-radius: 0;
+		// a left ribbon spans the full height of the card, so its bottom corner is
+		// only rounded when the card itself is rounded at the bottom
+		#{$root}:not(.-ds-radiusNone):not(.-ds-radiusTop).-ds-leftRibbon & {
+			border-bottom-left-radius: $card-border-radius;
 		}
 
 		.-ds-leftRibbon & {
@@ -213,13 +247,18 @@ import DsDivider from '../../Divider/Divider.vue';
 import DsLoadingBar, { LOADING_BAR_COLORS, LoadingBarColors } from '../../LoadingBar';
 import DsContainerRibbon from '../../ContainerRibbon/ContainerRibbon.vue';
 import { CONTAINER_RIBBON_LAYOUTS, CONTAINER_RIBBON_RADIUSES } from '../../ContainerRibbon';
+import { RemovedProp } from '../../../utils/type.utils';
 import {
 	CARD_BACKGROUND_COLORS,
+	CARD_ELEVATIONS,
+	CARD_RADIUSES,
 	CARD_RIBBON_COLORS,
 	CARD_RIBBON_POSITIONS,
 	CARD_RIBBON_SIZES,
 	CARD_PADDING_SIZES,
 	CardBackgroundColor,
+	CardElevation,
+	CardRadius,
 	CardRibbonColors,
 	CardRibbonPositions,
 	CardRibbonSizes,
@@ -234,7 +273,8 @@ const {
 	paddingSize = CARD_PADDING_SIZES.SMALL,
 	dividerUnderHeader = false,
 	hasRibbon = false,
-	hasRadius = true,
+	elevation = CARD_ELEVATIONS.DEFAULT,
+	radius = CARD_RADIUSES.ALL,
 	backgroundColor = CARD_BACKGROUND_COLORS.DEFAULT,
 	ribbonPosition = CARD_RIBBON_POSITIONS.TOP,
 	ribbonSize = CARD_RIBBON_SIZES.MEDIUM,
@@ -243,7 +283,6 @@ const {
 	hasLoadingBar = false,
 	loadingBarColor = LOADING_BAR_COLORS.NEUTRAL_HEAVY,
 	loadingBarTime = '0',
-	isFlat = false,
 	isContentScrollable = false,
 } = defineProps<{
 	contentHasPadding?: boolean;
@@ -252,7 +291,8 @@ const {
 	paddingSize?: CardPaddingSize;
 	dividerUnderHeader?: boolean;
 	hasRibbon?: boolean;
-	hasRadius?: boolean;
+	elevation?: CardElevation;
+	radius?: CardRadius;
 	backgroundColor?: CardBackgroundColor;
 	ribbonPosition?: CardRibbonPositions;
 	ribbonSize?: CardRibbonSizes;
@@ -261,8 +301,12 @@ const {
 	hasLoadingBar?: boolean;
 	loadingBarColor?: LoadingBarColors;
 	loadingBarTime?: string;
-	isFlat?: boolean;
 	isContentScrollable?: boolean;
+	// Removed props kept as removal markers so existing usages fail type-checking.
+	/** @deprecated use `elevation="none"`, `radius="none"` and `background-color="none"` */
+	isFlat?: RemovedProp<'use elevation, radius and backgroundColor'>;
+	/** @deprecated renamed to `radius` (all | top | none) */
+	hasRadius?: RemovedProp<'renamed to radius'>;
 }>();
 
 defineSlots<{
@@ -285,7 +329,7 @@ const ribbonRadius = computed(() => {
 		[CARD_RIBBON_POSITIONS.TOP]: CONTAINER_RIBBON_RADIUSES.BOTTOM,
 		[CARD_RIBBON_POSITIONS.LEFT]: CONTAINER_RIBBON_RADIUSES.RIGHT,
 	};
-	return hasRibbonRadius && (isFlat || !hasRadius)
+	return hasRibbonRadius && radius === CARD_RADIUSES.NONE
 		? ribbonPositionToRibbonRadiusMap[ribbonPosition]
 		: CONTAINER_RIBBON_RADIUSES.NONE;
 });

--- a/lib/js/components/Dropdown/Dropdown.vue
+++ b/lib/js/components/Dropdown/Dropdown.vue
@@ -36,30 +36,26 @@
 </template>
 
 <style lang="scss" scoped>
-@import '../../../../lib/styles/settings/colors/tokens';
-@import '../../../../lib/styles/settings/radiuses';
 @import '../../../../lib/styles/settings/spacings';
-@import '../../../../lib/styles/settings/shadows';
+@import '../../../../lib/styles/mixins/dropdown-surface';
 
 .ds-dropdown {
-	background-color: $color-default-background;
+	@include dropdownSurface;
+
+	// Resets for the styles vue-popperjs ships in vue-popper.css.
 	border: 0;
 	border-radius: 0;
-	box-shadow: $shadow-m;
 	max-width: 100%;
 	min-width: 128px;
-	overflow: hidden;
 	padding: 0;
 	text-align: left;
 
 	&.-ds-radiusBottom {
-		border-bottom-left-radius: $radius-s;
-		border-bottom-right-radius: $radius-s;
+		@include dropdownSurfaceRadiusBottom;
 	}
 
 	&.-ds-radiusTop {
-		border-top-left-radius: $radius-s;
-		border-top-right-radius: $radius-s;
+		@include dropdownSurfaceRadiusTop;
 	}
 
 	&[x-placement^='bottom'] {

--- a/lib/js/components/Form/Form.stories.ts
+++ b/lib/js/components/Form/Form.stories.ts
@@ -6,6 +6,7 @@ import { useForm } from 'vee-validate';
 import { toTypedSchema } from '@vee-validate/zod';
 import { array, object, string } from 'zod';
 import CheckboxGroupField from './CheckboxGroupField/CheckboxGroupField.vue';
+import SelectField from './SelectField';
 import Button from '../Buttons/Button';
 
 export default {
@@ -14,16 +15,18 @@ export default {
 } as Meta<any>;
 
 export const SimpleForm = () => ({
-	components: { InputField, CheckboxGroupField, Checkbox, Button },
+	components: { InputField, CheckboxGroupField, Checkbox, SelectField, Button },
 	setup: () => {
 		const { handleSubmit } = useForm({
 			initialValues: {
 				fullName: '',
+				country: '',
 				newsletterTopics: [],
 			},
 			validationSchema: toTypedSchema(
 				object({
 					fullName: string().min(1, 'Imię i nazwisko jest wymagane'),
+					country: string().min(1, 'Kraj jest wymagany'),
 					newsletterTopics: array(string()).min(
 						1,
 						'Wybierz przynajmniej jeden temat newslettera',
@@ -43,11 +46,22 @@ export const SimpleForm = () => ({
 
 		return {
 			onSubmit,
+			countryOptions: [
+				{ value: 'pl', label: 'Polska' },
+				{ value: 'de', label: 'Niemcy' },
+				{ value: 'cz', label: 'Czechy' },
+			],
 		};
 	},
 	template: `
 		<form @submit.prevent="onSubmit" style="display: flex; flex-direction: column; gap: 16px; max-width: 400px;">
 			<InputField label="Imię i nazwisko" name="fullName" />
+			<SelectField
+				label="Kraj"
+				name="country"
+				placeholder="Wybierz kraj"
+				:options="countryOptions"
+			/>
 			<CheckboxGroupField label="Jakie tematy newslettera Cię interesują?" name="newsletterTopics">
 				<template #field>
 					<Checkbox value="technology">Technologia</Checkbox>

--- a/lib/js/components/Form/SelectField/SelectField.spec.ts
+++ b/lib/js/components/Form/SelectField/SelectField.spec.ts
@@ -311,18 +311,17 @@ describe('SelectField', () => {
 			});
 		});
 
-		it('should emit update:open when opening and closing', async () => {
-			const onOpen = vi.fn();
-			const wrapper = setup({ label: 'Label', 'onUpdate:open': onOpen });
+		it('should emit open-change when opening and closing', async () => {
+			const wrapper = setup({ label: 'Label' });
 
 			await open(wrapper);
 
-			expect(onOpen).toHaveBeenCalledWith(true);
+			expect(wrapper.emitted('open-change')).toEqual([[true]]);
 
 			await close();
 
 			expect(wrapper.find('button').attributes('aria-expanded')).toBe('false');
-			expect(onOpen).toHaveBeenCalledWith(false);
+			expect(wrapper.emitted('open-change')).toEqual([[true], [false]]);
 		});
 	});
 

--- a/lib/js/components/Form/SelectField/SelectField.spec.ts
+++ b/lib/js/components/Form/SelectField/SelectField.spec.ts
@@ -1,0 +1,436 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DOMWrapper, enableAutoUnmount, mount, VueWrapper } from '@vue/test-utils';
+import { ComputedRef, nextTick, Ref } from 'vue';
+import { ComponentProps } from 'vue-component-type-helpers';
+import { FormMeta, useForm } from 'vee-validate';
+import SelectField from './SelectField.vue';
+import Icon, { ICONS } from '../../Icons/Icon';
+import { FORM_FIELD_STATES } from '../FormField';
+import { SelectFieldOption, SelectFieldOptionGroup } from './SelectField.types';
+import { waitForExpectShort } from '../../../tests/helpers';
+
+const OPTIONS: Array<SelectFieldOption> = [
+	{ value: 'pl', label: 'Poland' },
+	{ value: 'de', label: 'Germany' },
+	{ value: 'jp', label: 'Japan', isDisabled: true },
+];
+
+const GROUPED_OPTIONS: Array<SelectFieldOption | SelectFieldOptionGroup> = [
+	{ value: 'all', label: 'All countries' },
+	{ label: 'Europe', options: [{ value: 'pl', label: 'Poland' }] },
+	{ label: 'Asia', options: [{ value: 'jp', label: 'Japan' }] },
+];
+
+enableAutoUnmount(afterEach);
+
+function setup(props?: Partial<ComponentProps<typeof SelectField>>) {
+	return mount(SelectField, {
+		props: { options: OPTIONS, ...props } as ComponentProps<typeof SelectField>,
+	});
+}
+
+/**
+ * Asserts that mounting throws. A throw inside `setup()` leaves the component without a render
+ * function, so Vue emits an extra "Invalid vnode type" warning on top of the error under test —
+ * `warnHandler` swallows it so the run stays clean without hiding warnings elsewhere.
+ */
+function expectMountToThrow(props: Partial<ComponentProps<typeof SelectField>>, expected?: RegExp) {
+	expect(() =>
+		mount(SelectField, {
+			props: { options: OPTIONS, ...props } as ComponentProps<typeof SelectField>,
+			global: { config: { warnHandler: () => {} } },
+		}),
+	).toThrowError(expected);
+}
+
+/**
+ * The dropdown is portalled to `<body>`, so it sits outside the wrapper's DOM subtree and
+ * `wrapper.find*` cannot reach it. A body-scoped `DOMWrapper` keeps the Test Utils API while
+ * querying the portal.
+ *
+ * `wrapper.findAllComponents(SelectFieldOption)` also crosses the Teleport, but it walks the
+ * component tree, so it matches even while the listbox is closed — reka mounts the content into
+ * an offscreen fragment — which would defeat the closed-state assertions below.
+ */
+const portal = () => new DOMWrapper(document.body);
+
+const optionElements = () => portal().findAll('[role="option"]');
+
+/** The trigger opens on `pointerdown`, which needs pointer-capture APIs jsdom lacks. */
+async function open(wrapper: VueWrapper) {
+	await wrapper.find('button').trigger('keydown', { key: 'ArrowDown' });
+	await nextTick();
+	await nextTick();
+}
+
+/** reka-ui dismisses via `onKeyStroke`, which listens on `window`. */
+async function close() {
+	// Triggered from <body> so the event bubbles up to that window listener.
+	await portal().trigger('keydown', { key: 'Escape' });
+	await nextTick();
+}
+
+describe('SelectField', () => {
+	describe('closed', () => {
+		it('should render the label and the placeholder when no value is selected', () => {
+			const wrapper = setup({ label: 'Label', placeholder: 'Select placeholder' });
+
+			expect(wrapper.find('.ds-selectField__trigger').exists()).toBe(true);
+			expect(wrapper.find('label').text()).toContain('Label');
+			expect(wrapper.find('.ds-selectField__value').text()).toBe('Select placeholder');
+			expect(
+				wrapper.find('.ds-selectField__value').attributes('data-placeholder'),
+			).toBeDefined();
+		});
+
+		it('should render the selected option label', async () => {
+			const wrapper = setup({ label: 'Label', modelValue: 'de' });
+
+			// Options register with reka once the offscreen content fragment is mounted.
+			await nextTick();
+
+			await waitForExpectShort(() => {
+				expect(wrapper.find('.ds-selectField__value').text()).toBe('Germany');
+			});
+			expect(
+				wrapper.find('.ds-selectField__value').attributes('data-placeholder'),
+			).toBeUndefined();
+		});
+
+		it('should render the left icon when provided', () => {
+			const wrapper = setup({ label: 'Label', leftIcon: ICONS.FA_TAG });
+
+			expect(
+				wrapper.findComponent<typeof Icon>('.ds-selectField__leftIcon').props().icon,
+			).toEqual(ICONS.FA_TAG);
+		});
+
+		it('should not render the left icon by default', () => {
+			const wrapper = setup({ label: 'Label' });
+
+			expect(wrapper.find('.ds-selectField__leftIcon').exists()).toBe(false);
+		});
+
+		it('should render a combobox trigger associated with the label', () => {
+			const wrapper = setup({ label: 'Label' });
+
+			const trigger = wrapper.find('button');
+			const fieldId = wrapper.find('label').attributes('for');
+
+			expect(trigger.attributes('role')).toBe('combobox');
+			expect(trigger.attributes('id')).toBe(fieldId);
+			expect(trigger.attributes('aria-expanded')).toBe('false');
+		});
+
+		it('should not render options while closed', () => {
+			setup();
+
+			expect(optionElements()).toHaveLength(0);
+		});
+
+		it.each([
+			{ state: FORM_FIELD_STATES.DISABLED, expectedClass: '-ds-disabled' },
+			{ state: FORM_FIELD_STATES.ERROR, expectedClass: '-ds-error' },
+		])('should handle state: $state', ({ state, expectedClass }) => {
+			const wrapper = setup({ state });
+
+			expect(wrapper.find('.ds-selectField__trigger').classes()).toContain(expectedClass);
+		});
+
+		it('should disable the trigger when state is DISABLED', () => {
+			const wrapper = setup({ state: FORM_FIELD_STATES.DISABLED });
+
+			expect(wrapper.find('button').attributes('disabled')).toBeDefined();
+		});
+
+		it('should throw when an option value is an empty string', () => {
+			expectMountToThrow(
+				{ options: [{ value: '', label: 'Empty' }] },
+				/must not be an empty string/,
+			);
+		});
+	});
+
+	describe('accessible name and description', () => {
+		it('should set aria-describedby only when a message is rendered', () => {
+			const withMessage = setup({ label: 'Label', messageText: 'Message text' });
+			const messageId = `${withMessage.find('label').attributes('for')}-message`;
+
+			expect(withMessage.find('button').attributes('aria-describedby')).toBe(messageId);
+			expect(withMessage.find(`#${messageId}`).exists()).toBe(true);
+
+			const withoutMessage = setup({ label: 'Label' });
+
+			expect(withoutMessage.find('button').attributes('aria-describedby')).toBeUndefined();
+		});
+
+		it('should use ariaLabel as the accessible name when no visible label is given', () => {
+			const wrapper = setup({ ariaLabel: 'Country' });
+
+			expect(wrapper.find('label').exists()).toBe(false);
+			expect(wrapper.find('button').attributes('aria-label')).toBe('Country');
+		});
+
+		it('should prefer the visible label over ariaLabel', () => {
+			const wrapper = setup({ label: 'Label', ariaLabel: 'Country' });
+
+			expect(wrapper.find('button').attributes('aria-label')).toBeUndefined();
+		});
+
+		it('should mark the trigger as required when hasRequiredIndicator is set', () => {
+			const wrapper = setup({ label: 'Label', hasRequiredIndicator: true });
+
+			expect(wrapper.find('button').attributes('aria-required')).toBe('true');
+		});
+	});
+
+	describe('open', () => {
+		it('should open on ArrowDown and render one option per entry', async () => {
+			const wrapper = setup({ label: 'Label' });
+
+			await open(wrapper);
+
+			expect(wrapper.find('button').attributes('aria-expanded')).toBe('true');
+			expect(optionElements()).toHaveLength(OPTIONS.length);
+		});
+
+		it('should expose the styling hook on the portalled content', async () => {
+			const wrapper = setup({ label: 'Label' });
+
+			await open(wrapper);
+
+			const content = portal().find('.ds-selectField__content');
+
+			expect(content.exists()).toBe(true);
+			// Vue never forwards this component's scope id to SelectContent's element (it renders
+			// through Presence's slot), which is why `.ds-selectField__content` is styled from the
+			// unscoped block. Keep that in mind before moving the rule into the scoped one.
+			expect(content.attributes('role')).toBe('listbox');
+		});
+
+		it.each([
+			{ maxHeight: 240, expected: '240px' },
+			{ maxHeight: '50vh', expected: '50vh' },
+			{ maxHeight: undefined, expected: '' },
+		])(
+			'should resolve the max-height custom property for maxHeight: $maxHeight',
+			async ({ maxHeight, expected }) => {
+				const wrapper = setup({ label: 'Label', maxHeight });
+
+				await open(wrapper);
+
+				const content = portal().find<HTMLElement>('.ds-selectField__content');
+
+				expect(content.element.style.getPropertyValue('--select-field-max-height')).toBe(
+					expected,
+				);
+			},
+		);
+
+		it('should match typeahead on the label only, ignoring the eyebrow text', async () => {
+			// 'Status' would win a prefix match on 's' if the eyebrow were part of `textValue`,
+			// and 'z' would then match nothing.
+			const wrapper = setup({
+				label: 'Label',
+				options: [
+					{ value: 'draft', label: 'Draft', eyebrowText: 'Status' },
+					{ value: 'archived', label: 'Zarchiwizowany', eyebrowText: 'Status' },
+				],
+			});
+
+			await open(wrapper);
+
+			await portal().find('.ds-selectField__content').trigger('keydown', { key: 'z' });
+
+			// Must be the option element itself: asserting on textContent would also pass for the
+			// listbox, whose text concatenates every option.
+			expect(document.activeElement).toBe(optionElements()[1].element);
+		});
+
+		it('should include the eyebrow text in the accessible name', async () => {
+			const wrapper = setup({
+				label: 'Label',
+				options: [{ value: 'draft', label: 'Draft', eyebrowText: 'Status' }],
+			});
+
+			await open(wrapper);
+
+			// The eyebrow sits outside SelectItemText, so it would otherwise be dropped.
+			expect(optionElements()[0].attributes('aria-label')).toBe('Status Draft');
+		});
+
+		it('should name each option via an aria-labelledby that resolves', async () => {
+			const wrapper = setup({ label: 'Label' });
+
+			await open(wrapper);
+
+			optionElements().forEach((option, index) => {
+				const labelledBy = option.attributes('aria-labelledby');
+
+				expect(labelledBy).toBeTruthy();
+
+				// Resolving an IDREF is document-scoped by definition, and `getElementById` avoids
+				// having to escape reka's generated ids into a selector.
+				const nameElement = document.getElementById(labelledBy as string);
+
+				expect(nameElement).not.toBeNull();
+				expect(nameElement?.textContent?.trim()).toBe(OPTIONS[index].label);
+			});
+		});
+
+		it('should mark a disabled option as aria-disabled', async () => {
+			const wrapper = setup({ label: 'Label' });
+
+			await open(wrapper);
+
+			expect(optionElements()[2].attributes('aria-disabled')).toBe('true');
+		});
+
+		it('should mark the selected option as checked', async () => {
+			const wrapper = setup({ label: 'Label', modelValue: 'de' });
+
+			await open(wrapper);
+
+			const [poland, germany] = optionElements();
+
+			expect(germany.attributes('aria-selected')).toBe('true');
+			expect(germany.attributes('data-state')).toBe('checked');
+			expect(poland.attributes('aria-selected')).toBe('false');
+		});
+
+		it('should emit update:modelValue when an option is selected with Enter', async () => {
+			const onUpdate = vi.fn();
+			const wrapper = setup({ label: 'Label', 'onUpdate:modelValue': onUpdate });
+
+			await open(wrapper);
+
+			await optionElements()[1].trigger('keydown', { key: 'Enter' });
+
+			await waitForExpectShort(() => {
+				expect(onUpdate).toHaveBeenCalledWith('de');
+			});
+		});
+
+		it('should emit update:open when opening and closing', async () => {
+			const onOpen = vi.fn();
+			const wrapper = setup({ label: 'Label', 'onUpdate:open': onOpen });
+
+			await open(wrapper);
+
+			expect(onOpen).toHaveBeenCalledWith(true);
+
+			await close();
+
+			expect(wrapper.find('button').attributes('aria-expanded')).toBe('false');
+			expect(onOpen).toHaveBeenCalledWith(false);
+		});
+	});
+
+	describe('grouped options', () => {
+		it('should render a named group per labelled group and none for ungrouped options', async () => {
+			const wrapper = setup({ label: 'Label', options: GROUPED_OPTIONS });
+
+			await open(wrapper);
+
+			const groups = portal().findAll('[role="group"]');
+
+			// Only 'Europe' and 'Asia' are groups; 'All countries' is ungrouped.
+			expect(groups).toHaveLength(2);
+
+			groups.forEach((group) => {
+				const labelledBy = group.attributes('aria-labelledby');
+
+				expect(labelledBy).toBeTruthy();
+				expect(document.getElementById(labelledBy as string)).not.toBeNull();
+			});
+
+			expect(
+				groups.map((group) => {
+					const labelledBy = group.attributes('aria-labelledby') as string;
+
+					return document.getElementById(labelledBy)?.textContent?.trim();
+				}),
+			).toEqual(['Europe', 'Asia']);
+
+			expect(optionElements()).toHaveLength(3);
+		});
+
+		it('should hide the separators between groups from assistive technology', async () => {
+			const wrapper = setup({ label: 'Label', options: GROUPED_OPTIONS });
+
+			await open(wrapper);
+
+			const separators = portal().findAll('.ds-selectListItemDivider');
+
+			// One before 'Europe' and one before 'Asia'.
+			expect(separators).toHaveLength(2);
+			separators.forEach((separator) => {
+				expect(separator.attributes('aria-hidden')).toBe('true');
+			});
+		});
+	});
+
+	describe('with vee-validate', () => {
+		const fieldName = 'country';
+
+		function setupWithForm(props?: Partial<ComponentProps<typeof SelectField>>) {
+			let errorsRef: ComputedRef<Partial<Record<'country', string | undefined>>> | undefined;
+			let metaRef: Ref<FormMeta<{ country: string }>> | undefined;
+
+			const FormComponent = {
+				template: `
+					<form>
+						<SelectField v-bind="props" :name="name" :options="options" />
+					</form>
+				`,
+				components: { SelectField },
+				setup() {
+					const { errors, meta } = useForm({
+						initialValues: { [fieldName]: '' },
+						validationSchema: {
+							country: (val: string) => (val ? true : 'Country is required'),
+						},
+					});
+
+					errorsRef = errors;
+					metaRef = meta;
+
+					return { name: fieldName, options: OPTIONS, props };
+				},
+			};
+
+			return { wrapper: mount(FormComponent), errorsRef, metaRef };
+		}
+
+		it('should mark the form as touched when the listbox closes', async () => {
+			const { wrapper, metaRef } = setupWithForm();
+
+			expect(metaRef?.value.touched).toBe(false);
+
+			await open(wrapper);
+			await close();
+
+			await waitForExpectShort(() => {
+				expect(metaRef?.value.touched).toBe(true);
+			});
+		});
+
+		it('should surface a validation error as the field message', async () => {
+			const { wrapper, errorsRef } = setupWithForm();
+
+			await open(wrapper);
+			await close();
+
+			await waitForExpectShort(() => {
+				expect(errorsRef?.value?.country).toBe('Country is required');
+			});
+
+			expect(wrapper.find('.ds-selectField__trigger').classes()).toContain('-ds-error');
+			expect(wrapper.find('.ds-formFieldMessage').text()).toBe('Country is required');
+		});
+
+		it('should throw when name is used outside a form context', () => {
+			expectMountToThrow({ name: 'country' });
+		});
+	});
+});

--- a/lib/js/components/Form/SelectField/SelectField.stories.ts
+++ b/lib/js/components/Form/SelectField/SelectField.stories.ts
@@ -1,0 +1,229 @@
+import { Meta, StoryObj } from '@storybook/vue3';
+import { reactive, toRefs } from 'vue';
+import { withActions } from '@storybook/addon-actions/decorator';
+import SelectField from './SelectField.vue';
+import HelpButton from '../../Buttons/HelpButton/HelpButton.vue';
+import Modal from '../../Modals/Modal';
+import { ICONS } from '../../Icons/Icon';
+import { args, argTypes } from '../FormField/FormField.stories.shared';
+import { FORM_FIELD_STATES } from '../FormField/FormField.consts';
+import { SelectFieldOption, SelectFieldOptionGroup } from './SelectField.types';
+
+const OPTIONS: Array<SelectFieldOption> = [
+	{ value: 'pl', label: 'Polska' },
+	{ value: 'de', label: 'Niemcy' },
+	{ value: 'cz', label: 'Czechy' },
+	{ value: 'sk', label: 'Słowacja', isDisabled: true },
+	{ value: 'jp', label: 'Japonia' },
+];
+
+const GROUPED_OPTIONS: Array<SelectFieldOption | SelectFieldOptionGroup> = [
+	{ value: 'all', label: 'Wszystkie kraje' },
+	{
+		label: 'Europa',
+		options: [
+			{ value: 'pl', label: 'Polska' },
+			{ value: 'de', label: 'Niemcy' },
+			{ value: 'cz', label: 'Czechy' },
+		],
+	},
+	{
+		label: 'Azja',
+		options: [
+			{ value: 'jp', label: 'Japonia' },
+			{ value: 'kr', label: 'Korea Południowa' },
+		],
+	},
+];
+
+const RICH_OPTIONS: Array<SelectFieldOption> = [
+	{ value: 'draft', label: 'Szkic', eyebrowText: 'Status', iconLeft: ICONS.FA_PENCIL },
+	{
+		value: 'published',
+		label: 'Opublikowany',
+		eyebrowText: 'Status',
+		iconLeft: ICONS.FA_CHECK_SOLID,
+	},
+	{ value: 'archived', label: 'Zarchiwizowany', eyebrowText: 'Status', iconLeft: ICONS.FA_BOX },
+];
+
+const LONG_OPTIONS: Array<SelectFieldOption> = Array.from({ length: 30 }, (_, index) => ({
+	value: `option-${index + 1}`,
+	label: `Opcja numer ${index + 1}`,
+}));
+
+const LONG_LABEL_OPTIONS: Array<SelectFieldOption> = [
+	{ value: 'anatomia', label: 'Anatomia prawidłowa człowieka z elementami histologii' },
+	{ value: 'biochemia', label: 'Biochemia kliniczna i diagnostyka laboratoryjna' },
+	{ value: 'farmakologia', label: 'Farmakologia z toksykologią dla kierunku lekarskiego' },
+	{ value: 'short', label: 'Krótka nazwa' },
+	{
+		value: 'bardzo-dlugi',
+		label: 'Wyjątkowo długa nazwa kursu, która nie zmieści się w dostępnej szerokości okna i zostanie skrócona wielokropkiem',
+	},
+];
+
+const meta: Meta<typeof SelectField> = {
+	title: 'Components/Form/SelectField',
+	component: SelectField,
+	decorators: [withActions],
+	render: (args) => ({
+		components: { SelectField, HelpButton, Modal },
+		setup() {
+			const { help, labelAside, message, fieldStatus, ...restRefs } = toRefs(args);
+			const props = reactive({ ...restRefs });
+
+			return {
+				props,
+				labelAside,
+				fieldStatus,
+				message,
+				help,
+				FORM_FIELD_STATES,
+				ICONS,
+			};
+		},
+		data: () => ({
+			value: undefined,
+		}),
+		template: `<SelectField v-bind="props" :left-icon="props.leftIcon ? ICONS[props.leftIcon] : null" v-model="value">
+			<template v-if="help" #help>
+				<HelpButton :is-disabled="props.state === FORM_FIELD_STATES.DISABLED" modal-title="Help modal title">
+					<template #modalContent>
+						Modal
+					</template>
+				</HelpButton>
+			</template>
+			<template #labelAside v-if="labelAside">
+				<div v-html="labelAside" />
+			</template>
+			<template #fieldStatus v-if="fieldStatus">
+				<div v-html="fieldStatus" />
+			</template>
+			<template #message v-if="message">
+				<div v-html="message" />
+			</template>
+		</SelectField>`,
+	}),
+	argTypes: {
+		...argTypes,
+		options: {
+			control: 'object',
+		},
+		placeholder: {
+			control: 'text',
+		},
+		leftIcon: {
+			control: 'select',
+			options: [null, ...Object.keys(ICONS)],
+		},
+		ariaLabel: {
+			control: 'text',
+		},
+		maxHeight: {
+			control: 'text',
+		},
+	},
+};
+export default meta;
+
+type Story = StoryObj<typeof SelectField>;
+
+export const Interactive: Story = {
+	args: {
+		...args,
+		options: OPTIONS,
+		placeholder: 'Wybierz kraj',
+		leftIcon: null,
+	},
+	parameters: {
+		design: {
+			type: 'figma',
+			url: 'https://www.figma.com/design/izQdYyiBR1GQgFkaOIfIJI/LMS---DS-Components?node-id=13216-6915',
+		},
+	},
+};
+
+export const WithGroups: Story = {
+	...Interactive,
+	args: {
+		...Interactive.args,
+		options: GROUPED_OPTIONS,
+	},
+	parameters: {},
+};
+
+export const WithIconsAndEyebrow: Story = {
+	...Interactive,
+	args: {
+		...Interactive.args,
+		options: RICH_OPTIONS,
+		placeholder: 'Wybierz status',
+	},
+	parameters: {},
+};
+
+/**
+ * The field is constrained to 360px while the option labels are much longer. Two behaviours to
+ * check here:
+ *
+ * - the trigger keeps the field's width and ellipsizes the selected label;
+ * - the dropdown uses the trigger width only as a *minimum*, widening to fit the longest
+ *   option, and stops at the space available in the viewport — where the last option, which is
+ *   longer still, ellipsizes inside the list.
+ *
+ * Try it near the right edge of the canvas, and switch to a mobile viewport, to see the
+ * `max-width` clamp take over.
+ */
+export const ConstrainedWidthWithLongLabels: Story = {
+	render: (args) => ({
+		components: { SelectField },
+		setup() {
+			return { args };
+		},
+		data: () => ({
+			// Preselected so the trigger's ellipsis is visible without opening the dropdown.
+			value: 'farmakologia',
+		}),
+		template: `
+			<div style="width: 360px;">
+				<SelectField v-bind="args" v-model="value" />
+			</div>
+		`,
+	}),
+	args: {
+		label: 'Kurs',
+		placeholder: 'Wybierz kurs',
+		options: LONG_LABEL_OPTIONS,
+	},
+};
+
+/** The dropdown caps at `maxHeight` (320px by default) and scrolls beyond it. */
+export const LongList: Story = {
+	...Interactive,
+	args: {
+		...Interactive.args,
+		options: LONG_OPTIONS,
+		placeholder: 'Wybierz opcję',
+	},
+	parameters: {},
+};
+
+export const Disabled: Story = {
+	...Interactive,
+	args: {
+		...Interactive.args,
+		state: FORM_FIELD_STATES.DISABLED,
+	},
+	parameters: {},
+};
+
+export const Error: Story = {
+	...Interactive,
+	args: {
+		...Interactive.args,
+		state: FORM_FIELD_STATES.ERROR,
+		messageText: 'Error message text',
+	},
+	parameters: {},
+};

--- a/lib/js/components/Form/SelectField/SelectField.types.ts
+++ b/lib/js/components/Form/SelectField/SelectField.types.ts
@@ -1,0 +1,52 @@
+import { FormFieldProps, FormFieldSlots } from '../FormField';
+import { IconItem } from '../../Icons/Icon';
+
+/**
+ * reka-ui reserves the empty string for clearing the selection, so `''` must never be
+ * used as an option value. `undefined` (or `''`/`null` coming from a form) renders the
+ * placeholder.
+ */
+export type SelectFieldValue = string | number;
+
+export interface SelectFieldOption {
+	value: SelectFieldValue;
+	label: string;
+	iconLeft?: IconItem | null;
+	eyebrowText?: string;
+	isDisabled?: boolean;
+}
+
+export interface SelectFieldOptionGroup {
+	/**
+	 * When set, the group is rendered as an accessible `role="group"` with this text as its
+	 * accessible name. Groups without a label render their options as direct children of the
+	 * listbox instead.
+	 */
+	label?: string;
+	options: Array<SelectFieldOption>;
+}
+
+export interface SelectFieldProps extends FormFieldProps {
+	options: Array<SelectFieldOption | SelectFieldOptionGroup>;
+	placeholder?: string;
+	leftIcon?: IconItem | null;
+	/**
+	 * Used as `aria-label` when no visible `label` is provided, so the field always has an
+	 * accessible name.
+	 */
+	ariaLabel?: string;
+	/**
+	 * Caps the dropdown height. A `number` is treated as pixels; a string is used as-is, so
+	 * any CSS length works. The dropdown never exceeds the space available in the viewport
+	 * regardless of this value.
+	 *
+	 * @default '320px'
+	 */
+	maxHeight?: string | number;
+	/**
+	 * vee-validate field name. Requires a surrounding `useForm()` context.
+	 */
+	name?: string;
+}
+
+export type SelectFieldSlots = Omit<FormFieldSlots, 'field'>;

--- a/lib/js/components/Form/SelectField/SelectField.utils.ts
+++ b/lib/js/components/Form/SelectField/SelectField.utils.ts
@@ -1,0 +1,83 @@
+import { SelectFieldOption, SelectFieldOptionGroup } from './SelectField.types';
+
+export function isSelectFieldOptionGroup(
+	option: SelectFieldOption | SelectFieldOptionGroup,
+): option is SelectFieldOptionGroup {
+	return 'options' in option;
+}
+
+/**
+ * Normalises the mixed options prop into a list of groups, preserving order.
+ * Consecutive ungrouped options collapse into a single group without a label — such a group
+ * renders its options as direct children of the listbox, because an unlabelled reka-ui
+ * `SelectGroup` emits `role="group"` with a dangling `aria-labelledby`.
+ *
+ * Never mutates the `options` prop: synthesised groups own their arrays, and groups passed in
+ * by the consumer are copied before anything is appended to them.
+ */
+export function normalizeOptions(
+	options: Array<SelectFieldOption | SelectFieldOptionGroup>,
+): Array<SelectFieldOptionGroup> {
+	const groups: Array<SelectFieldOptionGroup> = [];
+	// Only a group synthesised here may absorb following ungrouped options.
+	let openGroup: SelectFieldOptionGroup | null = null;
+
+	options.forEach((option) => {
+		if (isSelectFieldOptionGroup(option)) {
+			groups.push({ ...option, options: [...option.options] });
+			openGroup = null;
+
+			return;
+		}
+
+		if (openGroup) {
+			openGroup.options.push(option);
+
+			return;
+		}
+
+		openGroup = { options: [option] };
+		groups.push(openGroup);
+	});
+
+	return groups;
+}
+
+/**
+ * reka-ui throws an opaque error when a `SelectItem` receives an empty string value.
+ * Fail earlier with a message that names the component.
+ */
+export function assertOptionValues(groups: Array<SelectFieldOptionGroup>): void {
+	const hasEmptyValue = groups.some(({ options }) => options.some(({ value }) => value === ''));
+
+	if (hasEmptyValue) {
+		throw new Error(
+			'[SelectField]: An option value must not be an empty string, because an empty string clears the selection.',
+		);
+	}
+}
+
+/**
+ * Resolves a CSS length prop: a `number` is treated as pixels, a string is passed through.
+ * Returns `undefined` for anything that must not reach the style attribute, so `0` still
+ * produces a usable `0px`.
+ */
+export function toCssLength(value: string | number | undefined): string | undefined {
+	if (typeof value === 'number') {
+		return `${value}px`;
+	}
+
+	return value || undefined;
+}
+
+/**
+ * reka-ui names an option after its `SelectItemText`, which only wraps the label, so the
+ * eyebrow text would be dropped from the accessible name. Prepend it so assistive technology
+ * announces everything that is visible.
+ *
+ * Deliberately *not* used for reka-ui's `textValue`: typeahead matches on a prefix, and users
+ * type the label rather than the eyebrow.
+ */
+export function getOptionAccessibleName(option: SelectFieldOption): string {
+	return option.eyebrowText ? `${option.eyebrowText} ${option.label}` : option.label;
+}

--- a/lib/js/components/Form/SelectField/SelectField.vue
+++ b/lib/js/components/Form/SelectField/SelectField.vue
@@ -1,0 +1,328 @@
+<template>
+	<form-field v-bind="formFieldProps">
+		<template #field="{ fieldId, messageId }">
+			<select-root
+				v-model="value"
+				:disabled="isDisabled"
+				:required="formFieldProps.hasRequiredIndicator"
+				@update:open="onOpenChange"
+			>
+				<select-trigger
+					:id="fieldId"
+					:aria-describedby="hasMessage ? messageId : undefined"
+					:aria-label="formFieldProps.label ? undefined : ariaLabel"
+					:class="[
+						'ds-selectField__trigger',
+						{
+							'-ds-error': formFieldProps.state === FORM_FIELD_STATES.ERROR,
+							'-ds-disabled': isDisabled,
+						},
+					]"
+				>
+					<ds-icon
+						v-if="leftIcon"
+						class="ds-selectField__leftIcon"
+						:icon="leftIcon"
+						:size="ICON_SIZES.X_SMALL"
+					/>
+					<select-value class="ds-selectField__value" :placeholder="placeholder" />
+					<select-icon as-child>
+						<ds-icon
+							class="ds-selectField__icon"
+							:icon="ICONS.FA_CHEVRON_DOWN"
+							:size="ICON_SIZES.X_SMALL"
+						/>
+					</select-icon>
+				</select-trigger>
+
+				<select-portal>
+					<select-content
+						class="ds-selectField__content"
+						position="popper"
+						align="start"
+						:side-offset="0"
+						:style="contentStyle"
+					>
+						<select-viewport as-child>
+							<ds-select-list>
+								<template
+									v-for="(group, groupIndex) in normalizedOptions"
+									:key="groupIndex"
+								>
+									<select-separator v-if="groupIndex > 0" as-child>
+										<ds-select-list-item-divider />
+									</select-separator>
+
+									<!-- A labelled group gets real `role="group"` semantics. -->
+									<select-group v-if="group.label">
+										<select-label as-child>
+											<ds-select-list-section-title :label="group.label" />
+										</select-label>
+										<select-field-option
+											v-for="option in group.options"
+											:key="option.value"
+											:option="option"
+											:is-selected="option.value === value"
+										/>
+									</select-group>
+
+									<!--
+										Ungrouped options render as direct children of the listbox:
+										an unlabelled SelectGroup would emit `role="group"` with a
+										dangling `aria-labelledby`.
+									-->
+									<template v-else>
+										<select-field-option
+											v-for="option in group.options"
+											:key="option.value"
+											:option="option"
+											:is-selected="option.value === value"
+										/>
+									</template>
+								</template>
+							</ds-select-list>
+						</select-viewport>
+					</select-content>
+				</select-portal>
+			</select-root>
+		</template>
+		<!-- begin: FormField slots -->
+		<template v-if="$slots.help" #help>
+			<slot name="help" />
+		</template>
+		<template v-if="$slots.labelAside" #labelAside>
+			<slot name="labelAside" />
+		</template>
+		<template v-if="$slots.message" #message="{ messageId }">
+			<slot name="message" :message-id="messageId" />
+		</template>
+		<template v-if="$slots.fieldStatus" #fieldStatus>
+			<slot name="fieldStatus" />
+		</template>
+		<!-- end: FormField slots -->
+	</form-field>
+</template>
+
+<style lang="scss" scoped>
+@import '../../../../styles/settings/spacings';
+@import '../../../../styles/settings/radiuses';
+@import '../../../../styles/settings/borders';
+@import '../../../../styles/settings/colors/tokens';
+@import '../../../../styles/settings/typography/tokens';
+@import '../../../../styles/settings/shadows';
+@import '../../../../styles/settings/animations';
+
+.ds-selectField {
+	$root: &;
+
+	// The element rules come before `&__trigger` so that the trigger's state overrides, which
+	// target the same elements at a higher specificity, stay in ascending order.
+	&__leftIcon {
+		color: $color-neutral-icon-weak;
+	}
+
+	&__value {
+		@include formText-s-default-regular;
+
+		color: $color-neutral-text-heavy;
+		flex: 1;
+		// override the default min-width so long values can ellipsize
+		min-width: 0;
+		overflow: hidden;
+		text-align: left;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+
+		&[data-placeholder] {
+			color: $color-neutral-text-weak;
+		}
+	}
+
+	&__icon {
+		color: $color-neutral-icon;
+		transition: $default-cubic-bezier-transition;
+	}
+
+	&__trigger {
+		align-items: center;
+		// FormField__field is `align-items: flex-start`, so the trigger must opt into full width.
+		align-self: stretch;
+		background: $color-default-background;
+		border: $border-xs solid $color-neutral-border-strong;
+		border-radius: $radius-s;
+		box-shadow: $shadow-inset-m;
+		cursor: pointer;
+		display: flex;
+		font-family: inherit;
+		gap: $space-4;
+		min-height: 32px;
+		// Focus is conveyed by the border color below, so the UA ring is suppressed
+		outline: none;
+		padding: 0 $space-4;
+		text-align: left;
+
+		// The trigger is a button, so `[data-state='open']` replaces InputField's `:focus-within`.
+		&[data-state='open'] {
+			border-color: $color-primary-border;
+
+			#{$root}__icon {
+				transform: rotate(180deg);
+			}
+		}
+
+		&:focus-visible {
+			border-color: $color-primary-border;
+		}
+
+		&.-ds-disabled {
+			border-color: $color-neutral-border-strong-disabled;
+			box-shadow: none;
+			cursor: default;
+
+			#{$root}__leftIcon {
+				color: $color-neutral-icon-weak-disabled;
+			}
+
+			#{$root}__value {
+				color: $color-neutral-text-heavy-disabled;
+
+				&[data-placeholder] {
+					color: $color-neutral-text-weak-disabled;
+				}
+			}
+
+			#{$root}__icon {
+				color: $color-neutral-icon-disabled;
+			}
+		}
+
+		// `:focus-visible` is excluded so that focusing an errored trigger shows the primary
+		// border, the same way InputField's error rule yields to `:focus-within`.
+		&.-ds-error:not([data-state='open']):not(:focus-visible) {
+			border-color: $color-danger-border;
+		}
+
+		&:hover:not(.-ds-disabled):not([data-state='open']) {
+			border-color: $color-neutral-border-strong-hovered;
+
+			#{$root}__icon {
+				color: $color-neutral-icon-hovered;
+			}
+		}
+	}
+}
+</style>
+
+<!--
+	`ds-selectField__content` is styled unscoped on purpose. SelectContent renders through
+	Presence's slot rather than as its root, so Vue never forwards this component's scope id to
+	that element — a scoped rule would not match it. It is also portalled to `<body>`, so
+	`:deep()` has no ancestor to hang off either. Same approach as DatePicker.vue.
+-->
+<style lang="scss">
+@import '../../../../styles/settings/radiuses';
+@import '../../../../styles/settings/z-indexes';
+@import '../../../../styles/mixins/dropdown-surface';
+
+.ds-selectField__content {
+	@include dropdownSurface;
+	@include dropdownSurfaceRadiusBottom;
+
+	// SelectViewport owns the scrolling; this is the flex column that caps the height.
+	display: flex;
+	flex-direction: column;
+	max-height: min(
+		var(--select-field-max-height, 320px),
+		var(--reka-select-content-available-height)
+	);
+	// Widens to fit the longest option but never narrower than the trigger, and never wider
+	// than the space available in the viewport.
+	max-width: var(--reka-select-content-available-width);
+	min-width: var(--reka-select-trigger-width);
+	// Portalled to <body>, so it has to clear modals
+	z-index: $z-index-modal + 1;
+}
+</style>
+
+<script lang="ts" setup>
+import { computed, CSSProperties } from 'vue';
+import {
+	SelectContent,
+	SelectGroup,
+	SelectIcon,
+	SelectLabel,
+	SelectPortal,
+	SelectRoot,
+	SelectSeparator,
+	SelectTrigger,
+	SelectValue,
+	SelectViewport,
+} from 'reka-ui';
+import FormField, { FORM_FIELD_STATES, FormFieldProps } from '../FormField';
+import { extractFormFieldProps } from '../FormField/FormField.utils';
+import DsIcon, { ICON_SIZES, ICONS } from '../../Icons/Icon';
+import DsSelectList from '../../SelectList/SelectList.vue';
+import DsSelectListItemDivider from '../../SelectList/SelectListItemDivider/SelectListItemDivider.vue';
+import DsSelectListSectionTitle from '../../SelectList/SelectListSectionTitle/SelectListSectionTitle.vue';
+import SelectFieldOption from './SelectFieldOption.vue';
+import { SelectFieldProps, SelectFieldSlots, SelectFieldValue } from './SelectField.types';
+import { assertOptionValues, normalizeOptions, toCssLength } from './SelectField.utils';
+import { useSelectFieldWithinForm } from './useSelectFieldWithinForm';
+
+const { options, placeholder, leftIcon, ariaLabel, maxHeight, name, ...rest } =
+	defineProps<SelectFieldProps>();
+
+const slots = defineSlots<SelectFieldSlots>();
+
+const emit = defineEmits<{
+	'update:open': [isOpen: boolean];
+}>();
+
+const modelValue = defineModel<SelectFieldValue>();
+
+const { value, errors, onClose } = useSelectFieldWithinForm(() => name, modelValue);
+
+const { formFieldProps, isDisabled, hasMessage } = useFormFieldState();
+const { normalizedOptions } = useOptions();
+
+const contentStyle = computed<CSSProperties | undefined>(() => {
+	const resolvedMaxHeight = toCssLength(maxHeight);
+
+	return resolvedMaxHeight
+		? ({ '--select-field-max-height': resolvedMaxHeight } as CSSProperties)
+		: undefined;
+});
+
+function onOpenChange(isOpen: boolean) {
+	// Closing the listbox is a select's equivalent of blur.
+	if (!isOpen) {
+		onClose(new Event('blur'));
+	}
+
+	emit('update:open', isOpen);
+}
+
+function useFormFieldState() {
+	const formFieldProps = computed<FormFieldProps>(() =>
+		// this is needed to avoid passing modelValue to FormField as prop
+		extractFormFieldProps(rest, errors.value),
+	);
+
+	const isDisabled = computed(() => formFieldProps.value.state === FORM_FIELD_STATES.DISABLED);
+
+	// Avoids pointing `aria-describedby` at a message element that is never rendered.
+	const hasMessage = computed(() => !!(formFieldProps.value.messageText || slots.message));
+
+	return { formFieldProps, isDisabled, hasMessage };
+}
+
+function useOptions() {
+	const normalizedOptions = computed(() => normalizeOptions(options));
+
+	// Dev-time guard, called synchronously so invalid options fail at mount instead of
+	// surfacing as an unhandled rejection while the offscreen content fragment renders.
+	assertOptionValues(normalizedOptions.value);
+
+	return { normalizedOptions };
+}
+</script>

--- a/lib/js/components/Form/SelectField/SelectField.vue
+++ b/lib/js/components/Form/SelectField/SelectField.vue
@@ -220,7 +220,6 @@
 	`:deep()` has no ancestor to hang off either. Same approach as DatePicker.vue.
 -->
 <style lang="scss">
-@import '../../../../styles/settings/radiuses';
 @import '../../../../styles/settings/z-indexes';
 @import '../../../../styles/mixins/dropdown-surface';
 
@@ -239,8 +238,10 @@
 	// than the space available in the viewport.
 	max-width: var(--reka-select-content-available-width);
 	min-width: var(--reka-select-trigger-width);
-	// Portalled to <body>, so it has to clear modals
-	z-index: $z-index-modal + 1;
+	// Portalled to <body>, so it needs to clear modal content. It sits on the modal layer
+	// rather than above it: the listbox is appended after the (also teleported) modal, so an
+	// equal z-index still paints it on top, and tooltips at 16777271 stay above both.
+	z-index: $z-index-modal;
 }
 </style>
 
@@ -275,7 +276,7 @@ const { options, placeholder, leftIcon, ariaLabel, maxHeight, name, ...rest } =
 const slots = defineSlots<SelectFieldSlots>();
 
 const emit = defineEmits<{
-	'update:open': [isOpen: boolean];
+	'open-change': [isOpen: boolean];
 }>();
 
 const modelValue = defineModel<SelectFieldValue>();
@@ -299,7 +300,7 @@ function onOpenChange(isOpen: boolean) {
 		onClose(new Event('blur'));
 	}
 
-	emit('update:open', isOpen);
+	emit('open-change', isOpen);
 }
 
 function useFormFieldState() {

--- a/lib/js/components/Form/SelectField/SelectFieldOption.vue
+++ b/lib/js/components/Form/SelectField/SelectFieldOption.vue
@@ -1,0 +1,51 @@
+<template>
+	<select-item
+		as-child
+		:value="option.value"
+		:disabled="option.isDisabled"
+		:text-value="option.label"
+		:aria-label="option.eyebrowText ? getOptionAccessibleName(option) : undefined"
+		class="ds-selectFieldOption"
+	>
+		<ds-select-list-item
+			:label="option.label"
+			:icon-left="option.iconLeft"
+			:eyebrow-text="option.eyebrowText"
+			:is-selected="isSelected"
+			:state="
+				option.isDisabled
+					? SELECT_LIST_ITEM_STATES.DISABLED
+					: SELECT_LIST_ITEM_STATES.DEFAULT
+			"
+		>
+			<!--
+				reka-ui names each option via `aria-labelledby` pointing at the id rendered by
+				SelectItemText, so the visible label must live inside it.
+			-->
+			<template #text>
+				<select-item-text>{{ option.label }}</select-item-text>
+			</template>
+		</ds-select-list-item>
+	</select-item>
+</template>
+
+<style lang="scss">
+.ds-selectFieldOption {
+	// The highlighted state is conveyed by SelectListItem's own styling, so the UA focus ring
+	// is suppressed
+	outline: none;
+}
+</style>
+
+<script lang="ts" setup>
+import { SelectItem, SelectItemText } from 'reka-ui';
+import DsSelectListItem from '../../SelectList/SelectListItem/SelectListItem.vue';
+import { SELECT_LIST_ITEM_STATES } from '../../SelectList/SelectListItem/SelectListItem.consts';
+import { SelectFieldOption as SelectFieldOptionType } from './SelectField.types';
+import { getOptionAccessibleName } from './SelectField.utils';
+
+const { option, isSelected = false } = defineProps<{
+	option: SelectFieldOptionType;
+	isSelected?: boolean;
+}>();
+</script>

--- a/lib/js/components/Form/SelectField/index.ts
+++ b/lib/js/components/Form/SelectField/index.ts
@@ -1,0 +1,5 @@
+import SelectField from './SelectField.vue';
+
+export * from './SelectField.types';
+
+export default SelectField;

--- a/lib/js/components/Form/SelectField/useSelectFieldWithinForm.ts
+++ b/lib/js/components/Form/SelectField/useSelectFieldWithinForm.ts
@@ -13,7 +13,7 @@ export function useSelectFieldWithinForm(
 	name: MaybeRefOrGetter<string | undefined>,
 	modelValue: Ref<SelectFieldValue | undefined>,
 ) {
-	const { value, errors, field } = useFormFieldWithinForm<SelectFieldValue>(name, modelValue);
+	const { value, errors, field } = useFormFieldWithinForm(name, modelValue);
 
 	const onClose = (event: Event) => {
 		field?.handleBlur(event, true);

--- a/lib/js/components/Form/SelectField/useSelectFieldWithinForm.ts
+++ b/lib/js/components/Form/SelectField/useSelectFieldWithinForm.ts
@@ -1,0 +1,27 @@
+import { MaybeRefOrGetter, Ref } from 'vue';
+import { useFormFieldWithinForm } from '../../../composables/useFormFieldWithinForm';
+import { SelectFieldValue } from './SelectField.types';
+
+/**
+ * Select counterpart of `useInputFieldWithinForm`. A select has no `input` event, so closing
+ * the listbox stands in for blur — that is when the field is marked touched.
+ *
+ * Revalidation on selection needs no handler here: vee-validate's `useField` defaults to
+ * `validateOnValueUpdate: true`, so changing the value already re-runs validation.
+ */
+export function useSelectFieldWithinForm(
+	name: MaybeRefOrGetter<string | undefined>,
+	modelValue: Ref<SelectFieldValue | undefined>,
+) {
+	const { value, errors, field } = useFormFieldWithinForm<SelectFieldValue>(name, modelValue);
+
+	const onClose = (event: Event) => {
+		field?.handleBlur(event, true);
+	};
+
+	return {
+		value,
+		errors,
+		onClose,
+	};
+}

--- a/lib/js/components/SelectList/SelectListItem/SelectListItem.spec.ts
+++ b/lib/js/components/SelectList/SelectListItem/SelectListItem.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { h } from 'vue';
+import { ComponentProps } from 'vue-component-type-helpers';
+import SelectListItem from './SelectListItem.vue';
+import { SELECT_LIST_ITEM_SIZES, SELECT_LIST_ITEM_STATES } from './SelectListItem.consts';
+import Icon, { ICONS } from '../../Icons/Icon';
+
+const setup = (props: ComponentProps<typeof SelectListItem>, slots = {}) =>
+	mount(SelectListItem, { props, slots });
+
+describe('SelectListItem', () => {
+	it('should render the label', () => {
+		const wrapper = setup({ label: 'Basic listItem' });
+
+		expect(wrapper.find('.ds-selectListItem').exists()).toBe(true);
+		expect(wrapper.find('.ds-selectListItem__text').text()).toBe('Basic listItem');
+		expect(wrapper.find('.ds-selectListItem').attributes('title')).toBe('Basic listItem');
+	});
+
+	it('should render the eyebrow text when provided', () => {
+		const wrapper = setup({ label: 'Label', eyebrowText: 'Eyebrow' });
+
+		expect(wrapper.find('.ds-selectListItem__eyebrowText').text()).toBe('Eyebrow');
+	});
+
+	it.each(Object.values(SELECT_LIST_ITEM_SIZES))('should render in size: %s', (size) => {
+		const wrapper = setup({ label: 'Label', size });
+
+		expect(wrapper.find('.ds-selectListItem').classes()).toContain(`-ds-${size}`);
+	});
+
+	it.each([
+		{ state: SELECT_LIST_ITEM_STATES.DISABLED, expectedClass: '-ds-disabled' },
+		{ state: SELECT_LIST_ITEM_STATES.LOADING, expectedClass: '-ds-loading' },
+	])('should apply $expectedClass for state $state', ({ state, expectedClass }) => {
+		const wrapper = setup({ label: 'Label', state });
+
+		expect(wrapper.find('.ds-selectListItem').classes()).toContain(expectedClass);
+	});
+
+	it('should render the check icon when selected', () => {
+		const wrapper = setup({ label: 'Label', isSelected: true });
+
+		expect(
+			wrapper.findComponent<typeof Icon>('.ds-selectListItem__iconRight').props().icon,
+		).toEqual(ICONS.FA_CHECK_SOLID);
+	});
+
+	it('should not render the check icon when not selected', () => {
+		const wrapper = setup({ label: 'Label' });
+
+		expect(wrapper.find('.ds-selectListItem__iconRight').exists()).toBe(false);
+	});
+
+	describe('text slot', () => {
+		it('should fall back to the label when the slot is not provided', () => {
+			const wrapper = setup({ label: 'Fallback label' });
+
+			expect(wrapper.find('.ds-selectListItem__text').text()).toBe('Fallback label');
+		});
+
+		it('should override the rendered label when the slot is provided', () => {
+			const wrapper = setup(
+				{ label: 'Prop label' },
+				{ text: () => h('span', { id: 'custom-text' }, 'Slot label') },
+			);
+
+			const text = wrapper.find('.ds-selectListItem__text');
+
+			expect(text.find('#custom-text').exists()).toBe(true);
+			expect(text.text()).toBe('Slot label');
+			// `label` is still used for the title attribute and typeahead fallback.
+			expect(wrapper.find('.ds-selectListItem').attributes('title')).toBe('Prop label');
+		});
+	});
+});

--- a/lib/js/components/SelectList/SelectListItem/SelectListItem.vue
+++ b/lib/js/components/SelectList/SelectListItem/SelectListItem.vue
@@ -27,7 +27,9 @@
 				:class="{ '-ds-uppercase': isEyebrowTextUppercase }"
 				>{{ eyebrowText }}</span
 			>
-			<span class="ds-selectListItem__text">{{ label }}</span>
+			<span class="ds-selectListItem__text"
+				><slot name="text">{{ label }}</slot></span
+			>
 		</span>
 
 		<slot name="metadata" />
@@ -197,6 +199,7 @@ const {
 const slots = defineSlots<{
 	accessory?: () => any;
 	metadata?: () => any;
+	text?: () => any;
 }>();
 
 const isLoading = computed(() => state === SELECT_LIST_ITEM_STATES.LOADING);

--- a/lib/js/composables/useFormFieldWithinForm.ts
+++ b/lib/js/composables/useFormFieldWithinForm.ts
@@ -1,9 +1,9 @@
 import { inject, MaybeRefOrGetter, ref, Ref, toValue } from 'vue';
 import { FormContextKey, useField } from 'vee-validate';
 
-export function useFormFieldWithinForm<T = string>(
+export function useFormFieldWithinForm<T>(
 	name: MaybeRefOrGetter<string | undefined>,
-	modelValue: Ref<T | undefined>,
+	modelValue: Ref<T>,
 ) {
 	const nameValue = toValue(name);
 	const form = inject(FormContextKey, null);
@@ -14,9 +14,9 @@ export function useFormFieldWithinForm<T = string>(
 		);
 	}
 
-	const field = nameValue ? useField<Array<string>>(nameValue, undefined) : null;
+	const field = nameValue ? useField<T>(nameValue, undefined) : null;
 
-	const value = field ? field.value : modelValue;
+	const value: Ref<T> = field ? field.value : modelValue;
 
 	return {
 		field,

--- a/lib/js/index.ts
+++ b/lib/js/index.ts
@@ -54,6 +54,8 @@ export { default as NumberInCircle } from './components/NumberInCircle';
 export { default as DsNumberInCircle } from './components/NumberInCircle';
 export * from './components/NumberInCircle/NumberInCircle.consts';
 export { default as DsPasswordField } from './components/Form/PasswordField';
+export { default as DsSelectField } from './components/Form/SelectField';
+export * from './components/Form/SelectField';
 export { default as TabItem } from './components/TabItem';
 export { default as DsTabItem } from './components/TabItem';
 export * from './components/TabItem/TabItem.consts';

--- a/lib/js/styles/Shadows/Shadows.stories.scss
+++ b/lib/js/styles/Shadows/Shadows.stories.scss
@@ -23,6 +23,22 @@
 		box-shadow: $shadow-xl;
 	}
 
+	&.-ds-shadowTopS {
+		box-shadow: $shadow-top-s;
+	}
+
+	&.-ds-shadowTopM {
+		box-shadow: $shadow-top-m;
+	}
+
+	&.-ds-shadowTopL {
+		box-shadow: $shadow-top-l;
+	}
+
+	&.-ds-shadowTopXl {
+		box-shadow: $shadow-top-xl;
+	}
+
 	&.-ds-shadowInsetS {
 		box-shadow: $shadow-inset-s;
 	}

--- a/lib/js/styles/Shadows/Shadows.stories.ts
+++ b/lib/js/styles/Shadows/Shadows.stories.ts
@@ -12,6 +12,10 @@ const shadows = [
 	{ name: 'shadow-m', modifier: '-ds-shadowM' },
 	{ name: 'shadow-l', modifier: '-ds-shadowL' },
 	{ name: 'shadow-xl', modifier: '-ds-shadowXl' },
+	{ name: 'shadow-top-s', modifier: '-ds-shadowTopS' },
+	{ name: 'shadow-top-m', modifier: '-ds-shadowTopM' },
+	{ name: 'shadow-top-l', modifier: '-ds-shadowTopL' },
+	{ name: 'shadow-top-xl', modifier: '-ds-shadowTopXl' },
 	{ name: 'shadow-inset-s', modifier: '-ds-shadowInsetS' },
 	{ name: 'shadow-inset-m', modifier: '-ds-shadowInsetM' },
 ];

--- a/lib/styles/mixins/_dropdown-surface.scss
+++ b/lib/styles/mixins/_dropdown-surface.scss
@@ -1,0 +1,24 @@
+@import '../settings/colors/tokens';
+@import '../settings/radiuses';
+@import '../settings/shadows';
+
+// The visual surface shared by floating panels — DsDropdown and SelectField's listbox.
+// Deliberately covers appearance only: sizing, scrolling and positioning stay with the
+// consumer, because those legitimately differ between popper engines and use cases.
+@mixin dropdownSurface {
+	background-color: $color-default-background;
+	box-shadow: $shadow-m;
+	overflow: hidden;
+}
+
+// Applied separately from `dropdownSurface`, since a panel anchored below its trigger keeps
+// its top corners square (and vice versa).
+@mixin dropdownSurfaceRadiusTop {
+	border-top-left-radius: $radius-s;
+	border-top-right-radius: $radius-s;
+}
+
+@mixin dropdownSurfaceRadiusBottom {
+	border-bottom-left-radius: $radius-s;
+	border-bottom-right-radius: $radius-s;
+}

--- a/lib/styles/settings/_shadows.scss
+++ b/lib/styles/settings/_shadows.scss
@@ -23,6 +23,24 @@ $shadow-xl:
 	0 16px 32px $color-default-shadow-strong,
 	0 0 4px $color-default-shadow;
 
+$shadow-top-s:
+	0 -1px 2px $color-default-shadow-weak,
+	0 -8px 16px $color-default-shadow-weak,
+	0 -2px 4px $color-default-shadow-strong,
+	0 0 4px $color-default-shadow;
+$shadow-top-m:
+	0 -2px 4px $color-default-shadow-weak,
+	0 -6px 12px $color-default-shadow-strong,
+	0 0 4px $color-default-shadow;
+$shadow-top-l:
+	0 -4px 8px $color-default-shadow-weak,
+	0 -10px 20px $color-default-shadow-strong,
+	0 0 4px $color-default-shadow;
+$shadow-top-xl:
+	0 -8px 16px $color-default-shadow-weak,
+	0 -16px 32px $color-default-shadow-strong,
+	0 0 4px $color-default-shadow;
+
 $shadow-inset-m: inset 0 1px 4px $color-default-shadow-heavy;
 $shadow-inset-s: inset 0 1px 3px $color-default-shadow-heavy;
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -14,3 +14,11 @@ const i18n = createI18n({
 });
 
 config.global.plugins = [i18n];
+
+// jsdom does not implement ResizeObserver, which floating-ui's `autoUpdate` (used by
+// reka-ui's popper-based components, e.g. SelectField) requires.
+global.ResizeObserver = class ResizeObserver {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+};


### PR DESCRIPTION
Ongoing branch for the IT-7662 ecommerce component changes. More component work will be added here, so this stays a draft until the batch is complete.

## SelectField

New `DsSelectField` (`lib/js/components/Form/SelectField/`) — a single-select field built on reka-ui's `Select` primitives, wrapped in `FormField` so it shares the label / sub-label / help / message / field-status anatomy with the other form fields.

- `options` accepts a flat list, option groups (`{ label?, options }`) or a mix of both. `normalizeOptions` collapses consecutive ungrouped options into one unlabelled group and keeps the original order; a labelled group renders as a real `role="group"`, an unlabelled one renders its options as direct children of the listbox (an unlabelled reka `SelectGroup` would emit `role="group"` with a dangling `aria-labelledby`). A divider is inserted between groups.
- Options are rendered through the existing `SelectList` / `SelectListItem` / `SelectListSectionTitle` / `SelectListItemDivider` components, so the dropdown matches the rest of the design system. Each option supports `iconLeft`, `eyebrowText` and `isDisabled`.
- Props: `placeholder`, `leftIcon`, `ariaLabel` (used when there is no visible label), `maxHeight` (number → px, string → any CSS length; defaults to 320px and is always clamped to the space available in the viewport), plus `v-model` and an `update:open` event.
- vee-validate: passing `name` binds the field to the surrounding `useForm()` context via the new `useSelectFieldWithinForm`. A select has no `input` event, so closing the listbox stands in for blur and marks the field touched; validation errors surface as the field message and the error state.
- Trigger styling mirrors `InputField` (inset shadow, border colors for hover / focus / open / error / disabled) with the chevron rotating while open. The listbox is portalled to `<body>`, so `.ds-selectField__content` is styled from an unscoped block (same approach as `DatePicker.vue`), widens to the longest option but never below the trigger width, and scrolls past `maxHeight`.
- Stories cover the interactive playground, groups, icons + eyebrow text, a long list, long labels in a constrained width, disabled and error. `SelectField` was also added to the `Form/SimpleForm` story so the vee-validate wiring is visible next to the other fields.

## Card: elevation / radius / background / padding rework

Aligns Card with the redesigned Figma component, where the three visual axes are independent variants instead of being bundled into `isFlat`.

- New `elevation` prop (`default` | `top` | `none`) replacing the shadow part of `isFlat`. `top` casts the shadow upwards, for cards docked to the bottom of the viewport.
- `hasRadius` becomes `radius` (`all` | `top` | `none`), with `top` rounding only the upper corners.
- `backgroundColor` gains a `none` value, so the old `isFlat` look is composed from `elevation="none"` + `radius="none"` + `backgroundColor="none"`.
- New `medium` padding size (24px) between `small` (16px) and `large` (32px), applied across header, divider, content and footer.

Ribbon corner clipping now follows `radius` alone. A left ribbon spans the full card height, so its bottom corner is only rounded when the card is rounded at the bottom, and the ribbon's own radius applies only at `radius="none"`.

## Foundations: Shadows/Top tokens

Adds `$shadow-top-s/m/l/xl` from [Figma foundations](https://www.figma.com/design/CG4lkRM9SnX7Qjz6rZxLYZ/LMS---DS-Foundations?node-id=209-2868) — each mirrors its `$shadow-*` counterpart with negated Y offsets, reusing the theme-aware shadow colour tokens — plus the matching `foundations/Shadows` story entries. `elevation="top"` consumes `$shadow-top-s`.

## Supporting changes

- **`lib/styles/mixins/_dropdown-surface.scss`** — the floating-panel surface (background, `$shadow-m`, `overflow: hidden`) and its per-edge radius mixins, extracted so `DsDropdown` and SelectField's listbox stay in sync. `Dropdown.vue` now consumes the mixins instead of repeating the declarations; no visual change there.
- **`SelectListItem`** gains a `text` slot (falling back to `label`) so SelectField can wrap the visible label in reka's `SelectItemText`, which is what `aria-labelledby` and the trigger's value display point at. `label` is still used for the `title` attribute. Also adds the component's first spec file.
- **`vitest.setup.ts`** stubs `ResizeObserver`, which jsdom lacks and floating-ui's `autoUpdate` (used by every reka popper-based component) requires.
- **`lib/js/index.ts`** exports `DsSelectField` and the SelectField types.

## Breaking changes

- `isFlat` and `hasRadius` are removed. Both are kept as `RemovedProp` markers, so leftover usages fail `ts:check` with a migration hint and stay hidden from Storybook controls.
- The internal modifier classes changed: `-ds-flat` and `-ds-noRadius` are gone, replaced by `-ds-elevationTop` / `-ds-elevationNone`, `-ds-radiusTop` / `-ds-radiusNone` and `-ds-backgroundNone`. Relevant to any app targeting those classes in its own CSS.

No in-repo consumer passed `isFlat`, `hasRadius` or `paddingSize`, so no internal migration was needed. `CardExpandable` does not forward the new props (out of scope).

## Verification

`yarn format:check`, `yarn test` (560/560), `yarn ts:check` and `yarn lint` all clean. Visual pass in Storybook still pending review: the four new shadow tiles in light and dark, the `none`/`none`/`none` combo against the old `isFlat` look, `radius="top"` with both ribbon positions, and the SelectField stories (trigger states, grouped list, long list scrolling, long-label ellipsis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
