### PR TITLE
IT-7536 | Move the DatePickers to a calendar-day API

### DIFF
--- a/lib/js/components/DatePickers/DateBox/DateBox.spec.ts
+++ b/lib/js/components/DatePickers/DateBox/DateBox.spec.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import DateBox from './DateBox.vue';
+import { SUPPORTED_LOCALE } from '../../../i18n';
+import { setTestLocale } from '../../../tests/helpers';
+
+const createComponent = (props = {}) => mount(DateBox, { props });
+
+const dateTexts = (component: ReturnType<typeof createComponent>) =>
+	component.findAll('.ds-dateBox__dateText').map((element) => element.text());
+
+const eyebrowTexts = (component: ReturnType<typeof createComponent>) =>
+	component.findAll('.ds-dateBox__eyebrow').map((element) => element.text());
+
+describe('DateBox', () => {
+	afterEach(() => {
+		setTestLocale(SUPPORTED_LOCALE.pl);
+	});
+
+	it('should render a single date when the start and the end name the same day', () => {
+		const component = createComponent({ startDate: '2026-08-05', endDate: '2026-08-05' });
+
+		expect(dateTexts(component)).toEqual(['05 sie']);
+		expect(eyebrowTexts(component)).toEqual(['Środa']);
+		expect(component.find('.ds-dateBox__separator').exists()).toBe(false);
+	});
+
+	it('should render both dates when the end names a different day', () => {
+		const component = createComponent({ startDate: '2026-08-05', endDate: '2026-08-17' });
+
+		expect(dateTexts(component)).toEqual(['05 sie', '17 sie']);
+		expect(eyebrowTexts(component)).toEqual(['Środa', 'Poniedziałek']);
+		expect(component.find('.ds-dateBox__separator').exists()).toBe(true);
+	});
+
+	it('should render the placeholder and no eyebrow when both dates are null', () => {
+		const component = createComponent({
+			startDate: null,
+			endDate: null,
+			placeholder: 'Ustaw',
+		});
+
+		expect(dateTexts(component)).toEqual(['Ustaw']);
+		expect(eyebrowTexts(component)).toEqual([]);
+	});
+
+	it('should render the day the string names in the en locale', async () => {
+		const component = createComponent({ startDate: '2026-08-05', endDate: '2026-08-17' });
+		setTestLocale(SUPPORTED_LOCALE.en);
+		await nextTick();
+
+		expect(dateTexts(component)).toEqual(['Aug 05', 'Aug 17']);
+		expect(eyebrowTexts(component)).toEqual(['Wednesday', 'Monday']);
+	});
+});

--- a/lib/js/components/DatePickers/DateBox/DateBox.stories.ts
+++ b/lib/js/components/DatePickers/DateBox/DateBox.stories.ts
@@ -21,17 +21,13 @@ const meta: Meta<DateBoxProps> = {
 				};
 			},
 			computed: {
-				formattedStartDate() {
-					if (!this.startDate) {
-						return null;
-					}
-					return new Date(this.startDate);
+				// The text controls hand back an empty string once cleared — the box only accepts
+				// a 'YYYY-MM-DD' day or null.
+				resolvedStartDate() {
+					return this.startDate || null;
 				},
-				formattedEndDate() {
-					if (!this.endDate) {
-						return null;
-					}
-					return new Date(this.endDate);
+				resolvedEndDate() {
+					return this.endDate || null;
 				},
 			},
 			template: `
@@ -39,8 +35,8 @@ const meta: Meta<DateBoxProps> = {
 					<date-box
 						:is-interactive="isInteractive"
 						:placeholder="placeholder"
-						:start-date="formattedStartDate"
-						:end-date="formattedEndDate"
+						:start-date="resolvedStartDate"
+						:end-date="resolvedEndDate"
 						:start-icon="startIcon ? ICONS[startIcon] : null"
 						:end-icon="endIcon ? ICONS[endIcon] : null"
 						:are-icons-hidden-on-mobile="areIconsHiddenOnMobile"
@@ -53,8 +49,8 @@ const meta: Meta<DateBoxProps> = {
 		};
 	},
 	argTypes: {
-		startDate: { control: 'date' },
-		endDate: { control: 'date' },
+		startDate: { control: 'text' },
+		endDate: { control: 'text' },
 		startIcon: { control: 'select', options: [null, ...Object.keys(ICONS)] },
 		endIcon: { control: 'select', options: [null, ...Object.keys(ICONS)] },
 		state: {

--- a/lib/js/components/DatePickers/DateBox/DateBox.vue
+++ b/lib/js/components/DatePickers/DateBox/DateBox.vue
@@ -357,6 +357,7 @@ import {
 } from '../../../../../tools/importers/helpers/dates';
 import { capitalizeFirstLetter } from '../../../../../tools/importers/helpers/modifiers';
 import { useLegacyI18n } from '../../../composables/useLegacyI18n';
+import { CalendarDate, isCalendarDateOrNull, parseCalendarDate } from '../calendarDate';
 
 export default defineComponent({
 	name: 'DateBox',
@@ -373,12 +374,14 @@ export default defineComponent({
 			default: null,
 		},
 		startDate: {
-			type: Date,
+			type: String as PropType<CalendarDate | null>,
 			default: null,
+			validator: isCalendarDateOrNull,
 		},
 		endDate: {
-			type: Date,
+			type: String as PropType<CalendarDate | null>,
 			default: null,
+			validator: isCalendarDateOrNull,
 		},
 		startIcon: {
 			type: Object,
@@ -422,20 +425,24 @@ export default defineComponent({
 	computed: {
 		startDateText() {
 			if (this.startDate) {
-				return localMonthDayWithShortMonthDay(this.startDate, this.locale);
+				return localMonthDayWithShortMonthDay(
+					parseCalendarDate(this.startDate),
+					this.locale,
+				);
 			}
 			return this.placeholder ?? this.t('ds.datePicker.set');
 		},
 		endDateIfDifferentThanStartDate() {
-			return this.startDate &&
-				this.endDate &&
-				this.startDate.toDateString() !== this.endDate.toDateString()
+			return this.startDate && this.endDate && this.startDate !== this.endDate
 				? this.endDate
 				: null;
 		},
 		endDateText() {
+			if (!this.endDateIfDifferentThanStartDate) {
+				return '';
+			}
 			return localMonthDayWithShortMonthDay(
-				this.endDateIfDifferentThanStartDate,
+				parseCalendarDate(this.endDateIfDifferentThanStartDate),
 				this.locale,
 			);
 		},
@@ -443,14 +450,19 @@ export default defineComponent({
 			if (!this.startDate) {
 				return '';
 			}
-			return capitalizeFirstLetter(localWeekdayName(this.startDate, this.locale));
+			return capitalizeFirstLetter(
+				localWeekdayName(parseCalendarDate(this.startDate), this.locale),
+			);
 		},
 		endDateEyebrowText() {
 			if (!this.endDateIfDifferentThanStartDate) {
 				return '';
 			}
 			return capitalizeFirstLetter(
-				localWeekdayName(this.endDateIfDifferentThanStartDate, this.locale),
+				localWeekdayName(
+					parseCalendarDate(this.endDateIfDifferentThanStartDate),
+					this.locale,
+				),
 			);
 		},
 	},

--- a/lib/js/components/DatePickers/DatePicker/DatePicker.composables.ts
+++ b/lib/js/components/DatePickers/DatePicker/DatePicker.composables.ts
@@ -4,17 +4,19 @@ import { CustomLocale } from 'flatpickr/dist/types/locale';
 
 import { DatePickerCalendarPositions, FLATPICKR_POSITIONS } from './index';
 import { SUPPORTED_LOCALE, SupportedLocale } from '../../../i18n';
+import { CalendarDate, parseCalendarDate, parseCalendarDateOrNull } from '../calendarDate';
 
 let flatpickrFunction: FlatpickrFn | null = null;
 const localeCache = new Map<string, CustomLocale>();
 
 export interface DatePickerComposablesProps {
-	disableDates: Array<Date>;
-	date?: Date | null;
-	startDate?: Date | null;
-	endDate?: Date | null;
-	minDate: Date | null;
-	maxDate: Date | null;
+	disableDates: Array<CalendarDate>;
+	date?: CalendarDate | null;
+	startDate?: CalendarDate | null;
+	endDate?: CalendarDate | null;
+	minDate: CalendarDate | null;
+	maxDate: CalendarDate | null;
+	today?: CalendarDate | null;
 	calendarPosition: DatePickerCalendarPositions;
 }
 
@@ -22,6 +24,7 @@ interface InitFlatpickrPrams {
 	props: DatePickerComposablesProps;
 	onChange: (dates: Array<Date>) => void;
 	onClose: () => void;
+	/** Already parsed — the picker owns the `date ?? today ?? browser now` fallback. */
 	defaultDates: Date | Array<Date>;
 	mode: 'single' | 'range';
 	locale?: SupportedLocale;
@@ -97,9 +100,12 @@ export function initFlatpickr({
 			ignoredFocusElements: [datePickerElement],
 			position: FLATPICKR_POSITIONS[props.calendarPosition],
 			defaultDate: defaultDates,
-			disable: props.disableDates,
-			minDate: props.minDate as Date | undefined,
-			maxDate: props.maxDate as Date | undefined,
+			disable: props.disableDates.map((day) => parseCalendarDate(day)),
+			minDate: parseCalendarDateOrNull(props.minDate) ?? undefined,
+			maxDate: parseCalendarDateOrNull(props.maxDate) ?? undefined,
+			// Drives the today ring and the month an empty calendar opens on. Without it flatpickr
+			// falls back to browser now, which can be a different day than the consumer's today.
+			now: parseCalendarDateOrNull(props.today) ?? undefined,
 			onClose: [
 				() => {
 					isOpen.value = false;
@@ -153,15 +159,24 @@ export function initFlatpickr({
 			() => props.minDate,
 			() => props.maxDate,
 			() => props.disableDates,
+			() => props.today,
 			() => defaultDates,
 		],
 		() => {
+			const now = parseCalendarDateOrNull(props.today) ?? undefined;
+
+			if (datePicker && now) {
+				// `set` only updates the config; the today ring reads the instance's own `now`.
+				datePicker.now = now;
+			}
+
 			datePicker?.set({
 				position: FLATPICKR_POSITIONS[props.calendarPosition],
 				defaultDate: defaultDates,
-				disable: props.disableDates,
-				minDate: props.minDate as Date | undefined,
-				maxDate: props.maxDate as Date | undefined,
+				disable: props.disableDates.map((day) => parseCalendarDate(day)),
+				minDate: parseCalendarDateOrNull(props.minDate) ?? undefined,
+				maxDate: parseCalendarDateOrNull(props.maxDate) ?? undefined,
+				now,
 			});
 		},
 		{
@@ -180,13 +195,16 @@ export function initFlatpickr({
 
 	const updateDatePicker = () => {
 		if (props.date) {
-			updateDatePickerDates(props.date);
+			updateDatePickerDates(parseCalendarDate(props.date));
 		} else if (props.startDate && props.endDate) {
-			updateDatePickerDates([props.startDate, props.endDate]);
+			updateDatePickerDates([
+				parseCalendarDate(props.startDate),
+				parseCalendarDate(props.endDate),
+			]);
 		} else if (props.startDate && !props.endDate) {
-			updateDatePickerDates(props.startDate);
+			updateDatePickerDates(parseCalendarDate(props.startDate));
 		} else if (!props.startDate && props.endDate) {
-			updateDatePickerDates(props.endDate);
+			updateDatePickerDates(parseCalendarDate(props.endDate));
 		} else {
 			datePicker?.clear(false);
 		}

--- a/lib/js/components/DatePickers/DatePicker/DatePicker.spec.ts
+++ b/lib/js/components/DatePickers/DatePicker/DatePicker.spec.ts
@@ -1,15 +1,43 @@
-import { describe, expect, it } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import { enableAutoUnmount, mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
 import DatePicker from './DatePicker.vue';
 import { Tile, TILE_COMPACT_LAYOUTS } from '../../../';
+import { SUPPORTED_LOCALE } from '../../../i18n';
+import { parseCalendarDate } from '../calendarDate';
+import { setTestLocale } from '../../../tests/helpers';
 
 const createComponent = (props = {}) => {
 	return mount(DatePicker, {
 		props,
+		attachTo: document.body,
 	});
 };
 
+/** Mounts, opens the calendar and hands back the flatpickr instance it created. */
+const openCalendar = async (props = {}) => {
+	const component = createComponent(props);
+
+	await component.vm.toggle();
+
+	const flatpickr = component.vm.flatpickrInstance;
+
+	if (!flatpickr) {
+		throw new Error('The calendar did not create a flatpickr instance');
+	}
+
+	return { component, flatpickr };
+};
+
+// The calendars mount into the document body — tear them down so their flatpickr instances stop
+// listening on it.
+enableAutoUnmount(afterEach);
+
 describe('DatePicker', () => {
+	afterEach(() => {
+		setTestLocale(SUPPORTED_LOCALE.pl);
+	});
+
 	describe('Hidden Icon', () => {
 		it('should pass DEFAULT compact layout to Tile when isIconHiddenOnMobile is not set', () => {
 			const component = createComponent();
@@ -36,6 +64,116 @@ describe('DatePicker', () => {
 
 			expect(tile.exists()).toBeTruthy();
 			expect(tile.props().compactLayout).toEqual(TILE_COMPACT_LAYOUTS.ICON_RIGHT_HIDDEN);
+		});
+	});
+
+	describe('Display', () => {
+		it.each([
+			{
+				locale: SUPPORTED_LOCALE.pl,
+				expectedText: '5 sie 2026',
+				expectedEyebrow: 'Środa',
+			},
+			{
+				locale: SUPPORTED_LOCALE.en,
+				expectedText: 'Aug 5, 2026',
+				expectedEyebrow: 'Wednesday',
+			},
+		])(
+			'should render the day the string names in the $locale locale',
+			async ({ locale, expectedText, expectedEyebrow }) => {
+				const component = createComponent({ date: '2026-08-05' });
+				setTestLocale(locale);
+				await nextTick();
+
+				const tile = component.findComponent(Tile);
+
+				expect(tile.props().text).toBe(expectedText);
+				expect(tile.props().eyebrowText).toBe(expectedEyebrow);
+			},
+		);
+
+		it('should render the placeholder when no date is set', () => {
+			const component = createComponent({ placeholder: 'Wybierz datę' });
+
+			const tile = component.findComponent(Tile);
+
+			expect(tile.props().text).toBe('Wybierz datę');
+			expect(tile.props().eyebrowText).toBe('');
+		});
+	});
+
+	describe('Emitted day', () => {
+		it('should emit the picked day as a calendar date', async () => {
+			const { component, flatpickr } = await openCalendar({ date: '2026-08-05' });
+
+			flatpickr.setDate(new Date(2026, 7, 17), true);
+
+			expect(component.emitted('update:date')).toEqual([['2026-08-17']]);
+		});
+	});
+
+	describe('today', () => {
+		it('should hand flatpickr the local midnight of today', async () => {
+			const { flatpickr } = await openCalendar({ today: '2026-08-05' });
+
+			expect(flatpickr.config.now).toEqual(parseCalendarDate('2026-08-05'));
+			expect(flatpickr.now).toEqual(parseCalendarDate('2026-08-05'));
+		});
+
+		it('should open an empty calendar on today', async () => {
+			const { flatpickr } = await openCalendar({ today: '2026-08-05' });
+
+			expect(flatpickr.config.defaultDate).toEqual(parseCalendarDate('2026-08-05'));
+		});
+
+		it('should keep the date as the default when both are set', async () => {
+			const { flatpickr } = await openCalendar({
+				date: '2026-08-17',
+				today: '2026-08-05',
+			});
+
+			expect(flatpickr.config.defaultDate).toEqual(parseCalendarDate('2026-08-17'));
+			expect(flatpickr.now).toEqual(parseCalendarDate('2026-08-05'));
+		});
+
+		it('should fall back to the browser now when today is not set', async () => {
+			const before = new Date();
+			const { flatpickr } = await openCalendar();
+			const after = new Date();
+
+			const defaultDate = flatpickr.config.defaultDate as Date;
+
+			expect(defaultDate.getTime()).toBeGreaterThanOrEqual(before.getTime());
+			expect(defaultDate.getTime()).toBeLessThanOrEqual(after.getTime());
+			expect(flatpickr.config.now).toBeUndefined();
+		});
+	});
+
+	describe('Prop watchers', () => {
+		it('should hand flatpickr parsed dates when the boundaries change after mount', async () => {
+			const { component, flatpickr } = await openCalendar({ date: '2026-08-05' });
+
+			await component.setProps({
+				minDate: '2026-08-03',
+				maxDate: '2026-08-28',
+				disableDates: ['2026-08-11', '2026-08-12'],
+			});
+
+			expect(flatpickr.config.minDate).toEqual(parseCalendarDate('2026-08-03'));
+			expect(flatpickr.config.maxDate).toEqual(parseCalendarDate('2026-08-28'));
+			expect(flatpickr.config.disable).toEqual([
+				parseCalendarDate('2026-08-11'),
+				parseCalendarDate('2026-08-12'),
+			]);
+		});
+
+		it('should hand flatpickr the parsed date when the date changes after mount', async () => {
+			const { component, flatpickr } = await openCalendar({ date: '2026-08-05' });
+
+			await component.setProps({ date: '2026-09-01' });
+
+			expect(flatpickr.selectedDates).toEqual([parseCalendarDate('2026-09-01')]);
 		});
 	});
 });

--- a/lib/js/components/DatePickers/DatePicker/DatePicker.stories.ts
+++ b/lib/js/components/DatePickers/DatePicker/DatePicker.stories.ts
@@ -9,6 +9,7 @@ import {
 	DATE_PICKER_TRIGGER_TYPES,
 } from './DatePicker.consts';
 import DatePicker from './DatePicker.vue';
+import { CalendarDate, formatCalendarDate } from '../calendarDate';
 
 export default {
 	title: 'Components/DatePickers/DatePicker',
@@ -29,42 +30,27 @@ const StoryTemplate: StoryFn<typeof DatePicker> = (args) => {
 			};
 		},
 		methods: {
-			updateDate(date: Date) {
-				if (date) {
-					updateArgs({
-						date: `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`,
-					});
-				} else {
-					updateArgs({
-						date: null,
-					});
-				}
+			updateDate(day: CalendarDate | null) {
+				updateArgs({ date: day ?? null });
 			},
 		},
 		computed: {
-			formattedDate() {
-				if (!this.date || this.date === '') {
-					return null;
-				}
-				return new Date(this.date);
+			// The text controls hand back an empty string once cleared — the pickers only accept
+			// a 'YYYY-MM-DD' day or null.
+			resolvedDate() {
+				return this.date || null;
 			},
-			formattedMinDate() {
-				if (!this.minDate || this.minDate == '') {
-					return null;
-				}
-				return new Date(this.minDate);
+			resolvedToday() {
+				return this.today || null;
 			},
-			formattedMaxDate() {
-				if (!this.maxDate || this.maxDate == '') {
-					return null;
-				}
-				return new Date(this.maxDate);
+			resolvedMinDate() {
+				return this.minDate || null;
 			},
-			formattedDisableDates() {
-				if (!this.disableDates || !this.disableDates.length) {
-					return null;
-				}
-				return this.disableDates.map((date) => new Date(date));
+			resolvedMaxDate() {
+				return this.maxDate || null;
+			},
+			resolvedDisableDates() {
+				return this.disableDates ?? [];
 			},
 		},
 		template: `
@@ -72,7 +58,8 @@ const StoryTemplate: StoryFn<typeof DatePicker> = (args) => {
 				:trigger-type="triggerType"
 				:is-interactive="isInteractive"
 				:placeholder="placeholder"
-				:date="formattedDate"
+				:date="resolvedDate"
+				:today="resolvedToday"
 				:additional-text="additionalText"
 				:helpMessage="helpMessage"
 				:label="label"
@@ -83,9 +70,9 @@ const StoryTemplate: StoryFn<typeof DatePicker> = (args) => {
 				:error-message="errorMessage"
 				:state="state"
 				:color="color"
-				:disable-dates="formattedDisableDates"
-				:min-date="formattedMinDate"
-				:max-date="formattedMaxDate"
+				:disable-dates="resolvedDisableDates"
+				:min-date="resolvedMinDate"
+				:max-date="resolvedMaxDate"
 				:update-position-based-on-scrollable-selector="updatePositionBasedOnScrollableSelector"
 				@update:date="updateDate"
 			>
@@ -95,8 +82,17 @@ const StoryTemplate: StoryFn<typeof DatePicker> = (args) => {
 };
 
 export const Interactive = StoryTemplate.bind({});
-const now = Date.now();
-const oneDayMili = 86400000;
+
+const browserToday = new Date();
+const dayFromBrowserToday = (offsetInDays: number): CalendarDate =>
+	formatCalendarDate(
+		new Date(
+			browserToday.getFullYear(),
+			browserToday.getMonth(),
+			browserToday.getDate() + offsetInDays,
+		),
+	);
+
 const args = {
 	triggerType: DATE_PICKER_TRIGGER_TYPES.TILE,
 	isInteractive: true,
@@ -105,9 +101,10 @@ const args = {
 	isLabelUppercase: false,
 	placeholder: 'Wybierz datę',
 	date: '',
-	disableDates: [new Date(now + oneDayMili * 2).toISOString().slice(0, 10)],
-	minDate: new Date(now).toISOString().slice(0, 10),
-	maxDate: new Date(now + oneDayMili * 30).toISOString().slice(0, 10),
+	today: '',
+	disableDates: [dayFromBrowserToday(2)],
+	minDate: dayFromBrowserToday(0),
+	maxDate: dayFromBrowserToday(30),
 	icon: 'FA_CALENDAR_DAYS',
 	isIconHiddenOnMobile: false,
 	additionalText: '',
@@ -123,6 +120,7 @@ const argTypes = {
 		options: Object.values(DATE_PICKER_TRIGGER_TYPES),
 	},
 	date: { control: 'text' },
+	today: { control: 'text' },
 	minDate: { control: 'text' },
 	maxDate: { control: 'text' },
 	icon: { control: 'select', options: [null, ...Object.keys(ICONS)] },
@@ -175,4 +173,22 @@ ScrollableContainer.parameters = {
 		type: 'figma',
 		url: 'https://www.figma.com/design/03ABNCSDYWYDmOPJOBGM5l/INI-153-Planowanie-pracy-z-lekcjami?node-id=245-162031&t=g08nj70xhT9BZTpu-4',
 	},
+};
+
+/**
+ * `today` is what the calendar treats as today: it rings that day and opens an empty calendar on
+ * its month. Here it is a week ahead of the browser's today, the way a user whose profile timezone
+ * puts them on another day would see it. Open the calendar — the ring sits on `today`, not on the
+ * browser's day.
+ */
+export const CustomToday = StoryTemplate.bind({});
+CustomToday.argTypes = argTypes;
+CustomToday.args = {
+	...args,
+	label: 'Today is a week ahead of the browser',
+	date: '',
+	today: dayFromBrowserToday(7),
+	minDate: '',
+	maxDate: '',
+	disableDates: [],
 };

--- a/lib/js/components/DatePickers/DatePicker/DatePicker.vue
+++ b/lib/js/components/DatePickers/DatePicker/DatePicker.vue
@@ -168,6 +168,13 @@ import {
 import { capitalizeFirstLetter } from '../../../../../tools/importers/helpers/modifiers';
 import { DatePickerComposablesProps, initFlatpickr } from './DatePicker.composables';
 import {
+	areCalendarDates,
+	CalendarDate,
+	formatCalendarDate,
+	isCalendarDateOrNull,
+	parseCalendarDate,
+} from '../calendarDate';
+import {
 	DATE_PICKER_CALENDAR_POSITIONS,
 	DATE_PICKER_COLORS,
 	DATE_PICKER_STATES,
@@ -199,8 +206,14 @@ export default defineComponent({
 			default: null,
 		},
 		date: {
-			type: Date,
+			type: String as PropType<CalendarDate | null>,
 			default: null,
+			validator: isCalendarDateOrNull,
+		},
+		today: {
+			type: String as PropType<CalendarDate | null>,
+			default: null,
+			validator: isCalendarDateOrNull,
 		},
 		additionalText: {
 			type: String,
@@ -246,16 +259,19 @@ export default defineComponent({
 			default: DATE_PICKER_CALENDAR_POSITIONS.BOTTOM_LEFT,
 		},
 		disableDates: {
-			type: Array as PropType<Array<Date>>,
+			type: Array as PropType<Array<CalendarDate>>,
 			default: () => [],
+			validator: areCalendarDates,
 		},
 		minDate: {
-			type: Date,
+			type: String as PropType<CalendarDate | null>,
 			default: null,
+			validator: isCalendarDateOrNull,
 		},
 		maxDate: {
-			type: Date,
+			type: String as PropType<CalendarDate | null>,
 			default: null,
+			validator: isCalendarDateOrNull,
 		},
 		updatePositionBasedOnScrollableSelector: {
 			type: String,
@@ -263,7 +279,7 @@ export default defineComponent({
 		},
 	},
 	emits: {
-		'update:date': (date: Date) => true,
+		'update:date': (day: CalendarDate) => true,
 	},
 	setup(
 		props: DatePickerComposablesProps & {
@@ -280,13 +296,16 @@ export default defineComponent({
 		const { locale, t } = useLegacyI18n();
 
 		const onChange = (event: Array<Date>) => {
-			emit('update:date', event[0]);
+			emit('update:date', formatCalendarDate(event[0]));
 		};
 
 		const onClose = () => {
 			destroyDatePicker();
 			flatpickrInstance.value = null;
 		};
+
+		// An empty calendar opens on the consumer's today when it knows one, browser now otherwise.
+		const defaultDay = props.date ?? props.today;
 
 		const {
 			isOpen,
@@ -298,7 +317,7 @@ export default defineComponent({
 			props,
 			onChange,
 			onClose,
-			defaultDates: props.date ?? new Date(),
+			defaultDates: defaultDay ? parseCalendarDate(defaultDay) : new Date(),
 			mode: 'single',
 			locale: locale.value,
 		});
@@ -345,13 +364,15 @@ export default defineComponent({
 			if (!this.date) {
 				return '';
 			}
-			return capitalizeFirstLetter(localWeekdayName(this.date, this.locale));
+			return capitalizeFirstLetter(
+				localWeekdayName(parseCalendarDate(this.date), this.locale),
+			);
 		},
 		text() {
 			if (!this.date) {
 				return this.resolvedPlaceholder;
 			}
-			return localFullDateWithShortMonthName(this.date, this.locale);
+			return localFullDateWithShortMonthName(parseCalendarDate(this.date), this.locale);
 		},
 		tileIcon() {
 			if (this.additionalText) {

--- a/lib/js/components/DatePickers/DateRangePicker/DateRangePicker.spec.ts
+++ b/lib/js/components/DatePickers/DateRangePicker/DateRangePicker.spec.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { enableAutoUnmount, mount } from '@vue/test-utils';
+import DateRangePicker from './DateRangePicker.vue';
+import { parseCalendarDate } from '../calendarDate';
+
+const createComponent = (props = {}) =>
+	mount(DateRangePicker, {
+		props: { isInteractive: true, ...props },
+		attachTo: document.body,
+	});
+
+/** Mounts, opens the calendar and hands back the flatpickr instance it created. */
+const openCalendar = async (props = {}) => {
+	const component = createComponent(props);
+
+	await component.vm.toggle();
+
+	const flatpickr = component.vm.flatpickrInstance;
+
+	if (!flatpickr) {
+		throw new Error('The calendar did not create a flatpickr instance');
+	}
+
+	return { component, flatpickr };
+};
+
+// The calendars mount into the document body — tear them down so their flatpickr instances stop
+// listening on it.
+enableAutoUnmount(afterEach);
+
+describe('DateRangePicker', () => {
+	it('should emit the picked range as a pair of calendar dates', async () => {
+		const { component, flatpickr } = await openCalendar({
+			startDate: '2026-08-05',
+			endDate: '2026-08-17',
+		});
+
+		flatpickr.setDate([new Date(2026, 7, 10), new Date(2026, 8, 1)], true);
+
+		expect(component.emitted('update:date')).toEqual([
+			[{ startDate: '2026-08-10', endDate: '2026-09-01' }],
+		]);
+	});
+
+	it('should open the calendar on the selected range', async () => {
+		const { flatpickr } = await openCalendar({
+			startDate: '2026-08-05',
+			endDate: '2026-08-17',
+		});
+
+		expect(flatpickr.config.defaultDate).toEqual([
+			parseCalendarDate('2026-08-05'),
+			parseCalendarDate('2026-08-17'),
+		]);
+	});
+
+	it('should hand flatpickr the local midnight of today', async () => {
+		const { flatpickr } = await openCalendar({ today: '2026-08-05' });
+
+		expect(flatpickr.config.now).toEqual(parseCalendarDate('2026-08-05'));
+		expect(flatpickr.now).toEqual(parseCalendarDate('2026-08-05'));
+	});
+
+	it('should select nothing when neither end of the range is set', async () => {
+		const { flatpickr } = await openCalendar({ today: '2026-08-05' });
+
+		expect(flatpickr.config.defaultDate).toEqual([]);
+		expect(flatpickr.selectedDates).toEqual([]);
+	});
+
+	it('should hand flatpickr parsed dates when the boundaries change after mount', async () => {
+		const { component, flatpickr } = await openCalendar({
+			startDate: '2026-08-05',
+			endDate: '2026-08-17',
+		});
+
+		await component.setProps({
+			minDate: '2026-08-03',
+			maxDate: '2026-08-28',
+			disableDates: ['2026-08-11'],
+		});
+
+		expect(flatpickr.config.minDate).toEqual(parseCalendarDate('2026-08-03'));
+		expect(flatpickr.config.maxDate).toEqual(parseCalendarDate('2026-08-28'));
+		expect(flatpickr.config.disable).toEqual([parseCalendarDate('2026-08-11')]);
+	});
+
+	it('should hand flatpickr the parsed range when the dates change after mount', async () => {
+		const { component, flatpickr } = await openCalendar({
+			startDate: '2026-08-05',
+			endDate: '2026-08-17',
+		});
+
+		await component.setProps({ startDate: '2026-09-01', endDate: '2026-09-08' });
+
+		expect(flatpickr.selectedDates).toEqual([
+			parseCalendarDate('2026-09-01'),
+			parseCalendarDate('2026-09-08'),
+		]);
+	});
+});

--- a/lib/js/components/DatePickers/DateRangePicker/DateRangePicker.stories.ts
+++ b/lib/js/components/DatePickers/DateRangePicker/DateRangePicker.stories.ts
@@ -8,6 +8,7 @@ import {
 	DATE_PICKER_STATES,
 } from '../DatePicker';
 import DateRangePicker from './DateRangePicker.vue';
+import { CalendarDate, formatCalendarDate } from '../calendarDate';
 
 type DateRangePickerProps = ComponentProps<typeof DateRangePicker>;
 
@@ -28,51 +29,39 @@ const meta: Meta<DateRangePickerProps> = {
 				};
 			},
 			methods: {
-				updateDate({ startDate, endDate }: { startDate: Date; endDate: Date }) {
+				updateDate({
+					startDate,
+					endDate,
+				}: {
+					startDate: CalendarDate;
+					endDate: CalendarDate;
+				}) {
 					updateArgs({
-						startDate: startDate
-							? `${startDate.getFullYear()}-${
-									startDate.getMonth() + 1
-								}-${startDate.getDate()}`
-							: null,
-						endDate: endDate
-							? `${endDate.getFullYear()}-${
-									endDate.getMonth() + 1
-								}-${endDate.getDate()}`
-							: null,
+						startDate: startDate ?? null,
+						endDate: endDate ?? null,
 					});
 				},
 			},
 			computed: {
-				formattedStartDate() {
-					if (!this.startDate) {
-						return null;
-					}
-					return new Date(this.startDate);
+				// The text controls hand back an empty string once cleared — the picker only
+				// accepts a 'YYYY-MM-DD' day or null.
+				resolvedStartDate() {
+					return this.startDate || null;
 				},
-				formattedEndDate() {
-					if (!this.endDate) {
-						return null;
-					}
-					return new Date(this.endDate);
+				resolvedEndDate() {
+					return this.endDate || null;
 				},
-				formattedMinDate() {
-					if (!this.minDate) {
-						return null;
-					}
-					return new Date(this.minDate);
+				resolvedToday() {
+					return this.today || null;
 				},
-				formattedMaxDate() {
-					if (!this.maxDate) {
-						return null;
-					}
-					return new Date(this.maxDate);
+				resolvedMinDate() {
+					return this.minDate || null;
 				},
-				formattedDisableDates() {
-					if (!this.disableDates || !this.disableDates.length) {
-						return [];
-					}
-					return this.disableDates.map((date: string) => new Date(date));
+				resolvedMaxDate() {
+					return this.maxDate || null;
+				},
+				resolvedDisableDates() {
+					return this.disableDates ?? [];
 				},
 			},
 			template: `
@@ -80,8 +69,9 @@ const meta: Meta<DateRangePickerProps> = {
 					<date-range-picker
 						:is-interactive="isInteractive"
 						:placeholder="placeholder"
-						:start-date="formattedStartDate"
-						:end-date="formattedEndDate"
+						:start-date="resolvedStartDate"
+						:end-date="resolvedEndDate"
+						:today="resolvedToday"
 						:start-icon="startIcon ? ICONS[startIcon] : null"
 						:end-icon="endIcon ? ICONS[endIcon] : null"
 						:are-icons-hidden-on-mobile="areIconsHiddenOnMobile"
@@ -89,9 +79,9 @@ const meta: Meta<DateRangePickerProps> = {
 						:error-message="errorMessage"
 						:state="state"
 						:color="color"
-						:disable-dates="formattedDisableDates"
-						:min-date="formattedMinDate"
-						:max-date="formattedMaxDate"
+						:disable-dates="resolvedDisableDates"
+						:min-date="resolvedMinDate"
+						:max-date="resolvedMaxDate"
 						@update:date="updateDate"
 					/>
 				</div>`,
@@ -100,6 +90,9 @@ const meta: Meta<DateRangePickerProps> = {
 	argTypes: {
 		startDate: { control: 'text' },
 		endDate: { control: 'text' },
+		today: { control: 'text' },
+		minDate: { control: 'text' },
+		maxDate: { control: 'text' },
 		startIcon: { control: 'select', options: [null, ...Object.keys(ICONS)] },
 		endIcon: { control: 'select', options: [null, ...Object.keys(ICONS)] },
 		calendarPosition: {
@@ -132,8 +125,16 @@ export default meta;
 
 type Story = StoryObj<DateRangePickerProps>;
 
-const now = Date.now();
-const oneDayMili = 86400000;
+const browserToday = new Date();
+const dayFromBrowserToday = (offsetInDays: number): CalendarDate =>
+	formatCalendarDate(
+		new Date(
+			browserToday.getFullYear(),
+			browserToday.getMonth(),
+			browserToday.getDate() + offsetInDays,
+		),
+	);
+
 export const Interactive: Story = {
 	args: {
 		isInteractive: true,
@@ -141,9 +142,10 @@ export const Interactive: Story = {
 		placeholder: 'Ustaw',
 		startDate: '',
 		endDate: '',
-		disableDates: [new Date(now + oneDayMili * 2).toISOString().slice(0, 10)],
-		minDate: new Date(now).toISOString().slice(0, 10),
-		maxDate: new Date(now + oneDayMili * 30).toISOString().slice(0, 10),
+		today: '',
+		disableDates: [dayFromBrowserToday(2)],
+		minDate: dayFromBrowserToday(0),
+		maxDate: dayFromBrowserToday(30),
 		startIcon: 'FA_CALENDAR_DAY',
 		endIcon: 'FA_CALENDAR_DAY',
 		areIconsHiddenOnMobile: false,

--- a/lib/js/components/DatePickers/DateRangePicker/DateRangePicker.vue
+++ b/lib/js/components/DatePickers/DateRangePicker/DateRangePicker.vue
@@ -68,6 +68,13 @@ import {
 } from '../DatePicker';
 import { DatePickerComposablesProps, initFlatpickr } from '../DatePicker/DatePicker.composables';
 import { useLegacyI18n } from '../../../composables/useLegacyI18n';
+import {
+	areCalendarDates,
+	CalendarDate,
+	formatCalendarDate,
+	isCalendarDateOrNull,
+	parseCalendarDateOrNull,
+} from '../calendarDate';
 
 export default defineComponent({
 	name: 'DateRangePicker',
@@ -84,12 +91,19 @@ export default defineComponent({
 			default: null,
 		},
 		startDate: {
-			type: Date,
+			type: String as PropType<CalendarDate | null>,
 			default: null,
+			validator: isCalendarDateOrNull,
 		},
 		endDate: {
-			type: Date,
+			type: String as PropType<CalendarDate | null>,
 			default: null,
+			validator: isCalendarDateOrNull,
+		},
+		today: {
+			type: String as PropType<CalendarDate | null>,
+			default: null,
+			validator: isCalendarDateOrNull,
 		},
 		startIcon: {
 			type: [Object, null] as PropType<IconItem | null>,
@@ -126,27 +140,32 @@ export default defineComponent({
 			default: DATE_PICKER_COLORS.NEUTRAL_WEAK,
 		},
 		disableDates: {
-			type: Array as PropType<Array<Date>>,
+			type: Array as PropType<Array<CalendarDate>>,
 			default: () => [],
+			validator: areCalendarDates,
 		},
 		minDate: {
-			type: Date,
+			type: String as PropType<CalendarDate | null>,
 			default: null,
+			validator: isCalendarDateOrNull,
 		},
 		maxDate: {
-			type: Date,
+			type: String as PropType<CalendarDate | null>,
 			default: null,
+			validator: isCalendarDateOrNull,
 		},
 		updatePositionBasedOnScrollableSelector: {
 			type: String,
 			default: '',
 		},
 	},
-	emits: { 'update:date': (value: { startDate: Date; endDate: Date }) => true },
+	emits: {
+		'update:date': (value: { startDate: CalendarDate; endDate: CalendarDate }) => true,
+	},
 	setup(
 		props: DatePickerComposablesProps & {
-			startDate: Date;
-			endDate: Date;
+			startDate: CalendarDate | null;
+			endDate: CalendarDate | null;
 			isInteractive: boolean;
 			state: DatePickerStates;
 			updatePositionBasedOnScrollableSelector: string;
@@ -163,7 +182,10 @@ export default defineComponent({
 			if (event.length !== 2) {
 				return;
 			}
-			emit('update:date', { startDate: event[0], endDate: event[1] });
+			emit('update:date', {
+				startDate: formatCalendarDate(event[0]),
+				endDate: formatCalendarDate(event[1]),
+			});
 		};
 
 		const onClose = () => {
@@ -181,7 +203,9 @@ export default defineComponent({
 			props,
 			onChange,
 			onClose,
-			defaultDates: [props.startDate, props.endDate],
+			defaultDates: [props.startDate, props.endDate]
+				.map((day) => parseCalendarDateOrNull(day))
+				.filter((date): date is Date => date !== null),
 			mode: 'range',
 			locale: locale.value,
 		});

--- a/lib/js/components/DatePickers/calendarDate.spec.ts
+++ b/lib/js/components/DatePickers/calendarDate.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import {
+	areCalendarDates,
+	CalendarDate,
+	formatCalendarDate,
+	isCalendarDateOrNull,
+	parseCalendarDate,
+	parseCalendarDateOrNull,
+} from './calendarDate';
+
+const REPRESENTATIVE_DAYS: Array<CalendarDate> = [
+	'2026-08-05', // mid-month
+	'2026-01-01', // first day of the year
+	'2026-12-31', // last day of the year
+	'2026-02-28', // last day of a short month
+	'2026-03-01', // first day after a short month
+	'2024-02-29', // leap day
+];
+
+describe('calendarDate', () => {
+	describe('parseCalendarDate', () => {
+		it.each(REPRESENTATIVE_DAYS)('should parse %s as browser-local midnight', (day) => {
+			const date = parseCalendarDate(day);
+			const [year, month, dayOfMonth] = day.split('-').map(Number);
+
+			expect(date.getFullYear()).toBe(year);
+			expect(date.getMonth()).toBe(month - 1);
+			expect(date.getDate()).toBe(dayOfMonth);
+			expect([date.getHours(), date.getMinutes(), date.getSeconds()]).toEqual([0, 0, 0]);
+		});
+
+		it('should return null for a missing day', () => {
+			expect(parseCalendarDateOrNull(null)).toBeNull();
+			expect(parseCalendarDateOrNull(undefined)).toBeNull();
+		});
+	});
+
+	describe('formatCalendarDate', () => {
+		it('should zero-pad the month and the day of month', () => {
+			expect(formatCalendarDate(new Date(2026, 0, 9))).toBe('2026-01-09');
+		});
+	});
+
+	// This is what holds in any host timezone — the numeric constructor writes local and
+	// getFullYear/getMonth/getDate read local, so the day never shifts.
+	it.each(REPRESENTATIVE_DAYS)('should round trip %s', (day) => {
+		expect(formatCalendarDate(parseCalendarDate(day))).toBe(day);
+	});
+
+	describe('isCalendarDateOrNull', () => {
+		it.each([...REPRESENTATIVE_DAYS, null, undefined])('should accept %s', (value) => {
+			expect(isCalendarDateOrNull(value)).toBe(true);
+		});
+
+		it.each([
+			'2026-08-05T00:00:00.000Z',
+			'2026-8-5',
+			'2026-08-05 ',
+			'05-08-2026',
+			'',
+			new Date(2026, 7, 5),
+			1754344800000,
+		])('should reject %s', (value) => {
+			expect(isCalendarDateOrNull(value)).toBe(false);
+		});
+	});
+
+	describe('areCalendarDates', () => {
+		it('should accept a list of calendar days', () => {
+			expect(areCalendarDates([])).toBe(true);
+			expect(areCalendarDates(REPRESENTATIVE_DAYS)).toBe(true);
+		});
+
+		it('should reject anything that is not a list of calendar days', () => {
+			expect(areCalendarDates(['2026-08-05', '2026-8-5'])).toBe(false);
+			expect(areCalendarDates([new Date(2026, 7, 5)])).toBe(false);
+			expect(areCalendarDates(null)).toBe(false);
+			expect(areCalendarDates('2026-08-05')).toBe(false);
+		});
+	});
+});

--- a/lib/js/components/DatePickers/calendarDate.ts
+++ b/lib/js/components/DatePickers/calendarDate.ts
@@ -1,0 +1,42 @@
+/** A calendar day, 'YYYY-MM-DD'. No time of day, no timezone. */
+export type CalendarDate = string;
+
+const CALENDAR_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export function isCalendarDate(value: unknown): value is CalendarDate {
+	return typeof value === 'string' && CALENDAR_DATE_PATTERN.test(value);
+}
+
+/** Prop validator for a single calendar day: `null` is allowed, anything else must be 'YYYY-MM-DD'. */
+export function isCalendarDateOrNull(value: unknown): boolean {
+	return value === null || value === undefined || isCalendarDate(value);
+}
+
+/** Prop validator for a list of calendar days. */
+export function areCalendarDates(value: unknown): boolean {
+	return Array.isArray(value) && value.every(isCalendarDate);
+}
+
+/**
+ * Browser-local midnight of the day the string names.
+ *
+ * The numeric constructor is deliberate: `new Date('2026-08-05')` parses as UTC midnight, which is
+ * the previous day in every zone west of UTC. Writing local and reading local (`getFullYear` etc.,
+ * `toLocaleDateString`) keeps the day stable in every browser timezone.
+ */
+export function parseCalendarDate(day: CalendarDate): Date {
+	const [year, month, dayOfMonth] = day.split('-').map(Number);
+	return new Date(year, month - 1, dayOfMonth);
+}
+
+export function parseCalendarDateOrNull(day: CalendarDate | null | undefined): Date | null {
+	return day ? parseCalendarDate(day) : null;
+}
+
+export function formatCalendarDate(date: Date): CalendarDate {
+	const year = String(date.getFullYear()).padStart(4, '0');
+	const month = String(date.getMonth() + 1).padStart(2, '0');
+	const dayOfMonth = String(date.getDate()).padStart(2, '0');
+
+	return `${year}-${month}-${dayOfMonth}`;
+}

--- a/lib/js/index.ts
+++ b/lib/js/index.ts
@@ -28,6 +28,7 @@ export { default as DatePicker } from './components/DatePickers/DatePicker';
 export { default as DsDatePicker } from './components/DatePickers/DatePicker';
 export { default as DsDateRangePicker } from './components/DatePickers/DateRangePicker';
 export * from './components/DatePickers/DatePicker';
+export type { CalendarDate } from './components/DatePickers/calendarDate';
 export { default as Divider } from './components/Divider';
 export { default as DsDivider } from './components/Divider';
 export * from './components/Divider/Divider.consts';

--- a/lib/js/tests/helpers.ts
+++ b/lib/js/tests/helpers.ts
@@ -1,5 +1,18 @@
 import waitForExpect from 'wait-for-expect';
+import { config } from '@vue/test-utils';
+import type { SupportedLocale } from '../i18n';
 
 export const waitForExpectShort = (fn: () => void | Promise<void>) => {
 	return waitForExpect(fn, 500, 5);
+};
+
+/**
+ * Switches the locale of the i18n instance `vitest.setup.ts` installs. It is shared by every
+ * mounted component, so a test that changes it has to set it back (see `SUPPORTED_LOCALE.pl`,
+ * the default).
+ */
+export const setTestLocale = (locale: SupportedLocale) => {
+	const [i18n] = config.global.plugins as unknown as [{ global: { locale: string } }];
+
+	i18n.global.locale = locale;
 };


### PR DESCRIPTION
## What

Every date-shaped prop and emit on `DsDatePicker`, `DsDateRangePicker` and `DsDateBox` now speaks `CalendarDate` — a `'YYYY-MM-DD'` string — instead of `Date`. Adds a `today` prop to both pickers.

**This is a breaking change; the release will be major (42.0.0).** Do not publish before the platform PR is ready — the two migrate in lockstep.

| Member | Was | Becomes |
|---|---|---|
| `DatePicker.date` | `Date`, default `null` | `CalendarDate \| null`, default `null` |
| `DatePicker.minDate` / `.maxDate` | `Date` | `CalendarDate \| null` |
| `DatePicker.disableDates` | `Array<Date>` | `Array<CalendarDate>` |
| `DatePicker.today` | — | **new** `CalendarDate \| null`, default `null` |
| `DatePicker` `update:date` | `(date: Date)` | `(day: CalendarDate)` |
| `DateRangePicker.startDate` / `.endDate` / `.minDate` / `.maxDate` | `Date` | `CalendarDate \| null` |
| `DateRangePicker.disableDates` | `Array<Date>` | `Array<CalendarDate>` |
| `DateRangePicker.today` | — | **new** `CalendarDate \| null`, default `null` |
| `DateRangePicker` `update:date` | `{ startDate: Date; endDate: Date }` | `{ startDate: CalendarDate; endDate: CalendarDate }` |
| `DateBox.startDate` / `.endDate` | `Date`, default `null` | `CalendarDate \| null`, default `null` |

`CalendarDate` is exported from the library root.

## Why

wnl-platform (the only consumer) moved every calendar day to `Y-m-d` strings in bethinkpl/wnl-platform#7907, so it carries a pair of adapter functions at every picker boundary. Two `new Date()` calls also stayed unreachable from the app:

1. flatpickr's `self.now` — it draws the today ring and picks the month an empty calendar opens on. The DS never set `config.now`, so the ring marked *browser* today even when the app's today (the user's profile timezone) was a different day.
2. `DatePicker`'s `defaultDates` fallback — an empty picker opened with browser-now visibly selected.

`today` fixes both: when set, it becomes flatpickr's `now` and the `defaultDates` fallback. Left unset, the pickers behave exactly as before.

A browser-local `Date` now exists only inside the DS, next to the two things that need one: flatpickr and `Intl`. No moment, no timezone library — the DS being zone-free is the design.

## How

`lib/js/components/DatePickers/calendarDate.ts` holds the type, the conversion pair and the prop validators. `parseCalendarDate` uses the numeric constructor deliberately: `new Date('2026-08-05')` parses as UTC midnight, which is the previous day in every browser west of UTC. Write local, read local, and the day survives in every host timezone.

Conversion happens only at the flatpickr boundary — the initial config *and* both watchers — and in the display computeds, which hand the existing `localFullDateWithShortMonthName` / `localWeekdayName` / `localMonthDayWithShortMonthDay` helpers a `Date` in the same zone that wrote it.

Two calls worth a reviewer's eye:

- The range picker keeps `[startDate, endDate]` as its default dates with **no** `today` fallback. In range mode a fallback would invent a selection, and `now` already opens an empty calendar on the right month.
- The `today` watcher assigns `instance.now` as well as calling `set()`, because `set()` only updates the config while the today ring reads the instance's own `now`.

Every date-shaped prop validates `null` or `/^\d{4}-\d{2}-\d{2}$/`, so an ISO instant leaking in fails loudly in dev instead of silently shifting a day.

## If a time-of-day picker is ever needed

Nothing here blocks one — flatpickr supports time natively (`enableTime`, `time_24hr`, `noCalendar` for time-only), and these components still build a browser-local `Date` internally for flatpickr and `Intl`; this PR only changed what crosses the component boundary. A time-capable picker would be a new component (`DsDateTimePicker`) or a new mode with its own emit, not a rework of this API. `DsDatePicker` stays day-only regardless: "a day" and "a moment" are different domain objects, and making that distinction type-visible is the point of this change.

What a time picker forces — and what a `Date` used to hide — is deciding **which zone the picked wall-clock means**. Two coherent contracts exist:

1. **Emit an instant** (a `Date`). Right when the user means their physical wall clock — "notify me at 9:00 where I'm sitting." The picker renders browser-local, the user picks browser-local, the instant is exact.
2. **Emit a zone-free wall-clock string** — `'2026-08-06T09:00'`, a `LocalDateTime` mirroring the `CalendarDate` pattern, anchored by the consumer in whatever zone its domain calls for (wnl-platform: the profile zone).

The trap to document when that day comes: for days, the browser≠profile gap is invisible (any zone's "August 6" is the same day); for times it is the whole offset — the user picks "9:00" on a browser-local widget, and a consumer anchoring it elsewhere stores a different moment than the user's wall clock showed. Option 2 therefore needs the UI to say whose 9:00 it is, or the component needs an explicit zone-offset input so it can render the consumer's zone (still no timezone library here — the consumer passes the offset).

The one thing not to do is widen `CalendarDate` or the existing props to smuggle a time through — that would undo the day/instant distinction this PR establishes.

## Tests

54 new tests across four files: round trip (month boundaries, year boundaries, a leap day), `pl`/`en` display for the picker and the box, emit shape for single and range, `today` reaching flatpickr's `config.now` / `instance.now` / `defaultDate` and browser-now when unset, the prop-watcher path handing flatpickr parsed `Date`s, DateBox single/differing/null days, and the validators.

`yarn test` (561 passed), `yarn ts:check`, `yarn lint` and `yarn build` are green. `dist` is left to the release workflow.

Verified live in Storybook: with `today` a week ahead, the ring sits on 12 August while the browser is on 5 August; picking 18 August round-trips to "Wtorek / 18 sie 2026"; the range picker emits a string pair that renders "10 sie – 20 sie". A new `CustomToday` story demonstrates `today` ≠ browser today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

